### PR TITLE
Add health and internet data streams to allow list

### DIFF
--- a/wlanpi_core/services/system_service.py
+++ b/wlanpi_core/services/system_service.py
@@ -22,6 +22,8 @@ allowed_services = [
     "grafana-server",
     "cockpit",
     "wlanpi-grafana-scanner",
+    "wlanpi-grafana-health",
+    "wlanpi-grafana-internet",
 ]
 
 


### PR DESCRIPTION
This PR adds wlanpi-grafana-internet.service and wlanpi-grafana-health.service to the system services API allow list.