### PR TITLE
Stop slack workflow status from running on PRs outside of WLAN Pi

### DIFF
--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -38,7 +38,7 @@ jobs:
           path: ${{ steps.build-debian-package.outputs.deb-package }}
         
   slack-workflow-status:
-    if:  ${{ always() && (vars.SKIP_SLACK != 'true') }}
+    if: ${{ always() && (vars.SKIP_SLACK != 'true') && (github.repository_owner == 'WLAN-Pi') }}
     name: Post Workflow Status to Slack
     needs:
       - sbuild

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -62,7 +62,7 @@ jobs:
           packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
   
   slack-workflow-status:
-    if: ${{ always() && (vars.SKIP_SLACK != 'true') }}
+    if: ${{ always() && (vars.SKIP_SLACK != 'true') && (github.repository_owner == 'WLAN-Pi') }}
     name: Post Workflow Status to Slack
     needs:
       - sbuild


### PR DESCRIPTION
This PR prevents the slack workflow step in actions from running when the repository owner is not "WLAN-Pi". This step always fails in this scenario because secrets are not shared to PR repository owners.