### PR TITLE
Remove debus-python from dependabot allowlist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,4 @@ updates:
       - dependency-name: pydantic-settings
       - dependency-name: requests
       - dependency-name: psutil
-      - dependency-name: dbus-python
       - dependency-name: PyGObject


### PR DESCRIPTION
This PR attempts to fix this issue:

```
  Collecting dbus-python (from -r requirements.in (line 14))
    Using cached dbus-python-1.3.2.tar.gz
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'done'
    Preparing metadata (pyproject.toml): started
    Preparing metadata (pyproject.toml): finished with status 'error'
    error: subprocess-exited-with-error
```

https://github.com/WLAN-Pi/wlanpi-core/actions/runs/11154144792/job/31002936645