### PR TITLE
[dependabot] ignore dbus-python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
       - dependency-name: requests
       - dependency-name: psutil
       - dependency-name: PyGObject
+    ignore:
+      - dependency-name: dbus-python


### PR DESCRIPTION
This PR attempts to tell dependabot to ignore dbus-python since it's not clear how to configure the action to install libdbus-1-dev.