### PR TITLE
Fix you may only define one of `paths` and `paths-ignore` for a single event

### DIFF
--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -5,11 +5,6 @@ on:
   pull_request:
     paths:
       - 'debian/changelog'
-    paths-ignore: # ignore files that don't change build output
-      - '**.md'
-      - .github/dependabot.yml
-      - .gitignore
-      - LICENSE
 env:
   debpackagename: wlanpi-core
 jobs:

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -7,11 +7,6 @@ on:
       - main
     paths:
       - 'debian/changelog'
-    paths-ignore: # ignore files that don't change build output
-      - '**.md'
-      - .github/dependabot.yml
-      - .gitignore
-      - LICENSE
 env:
   debpackagename: wlanpi-core
 jobs:


### PR DESCRIPTION
Fix `you may only define one of `paths` and `paths-ignore` for a single event`

https://github.com/WLAN-Pi/wlanpi-core/actions/runs/11155996063/workflow