### PR TITLE
Update changelog entries from unreleased to unstable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-wlanpi-core (1.0.3) UNRELEASED; urgency=medium
+wlanpi-core (1.0.3) unstable; urgency=medium
 
   * Hardening by updating several depends 
 
  -- Josh Schmelzle <josh@joshschmelzle.com>  Sun, 29 Sep 2024 11:10:33 -0400
 
-wlanpi-core (1.0.2) UNRELEASED; urgency=medium
+wlanpi-core (1.0.2) unstable; urgency=medium
 
   * Non-maintainer upload.
   * Added and overhauled VLAN core features.
@@ -12,7 +12,7 @@ wlanpi-core (1.0.2) UNRELEASED; urgency=medium
 
  -- Michael Ketchel <michael.ketchel@gmail.com>  Wed, 11 Sep 2024 21:37:17 -0400
 
-wlanpi-core (1.0.1) UNRELEASED; urgency=medium
+wlanpi-core (1.0.1) unstable; urgency=medium
 
   * Add Network APIs for managing wlan0 via DBUS
 


### PR DESCRIPTION
This is to fix `dch -i` for #27 from @Orbitix