### PR TITLE
Stop Slack from running on PR from fork

### DIFF
--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -60,7 +60,7 @@ jobs:
           name: ${{ env.filename }}
           path: ${{ steps.build-debian-package.outputs.deb-package }}
   slack-workflow-status:
-    if: ${{ always() && (github.repository_owner == 'WLAN-Pi') }}
+    if: ${{ always() && (github.repository_owner == 'WLAN-Pi') && (github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Post Workflow Status to Slack
     needs:
       - sbuild

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -82,7 +82,7 @@ jobs:
           packagecloud-distrib: debian/${{ matrix.distro }}
           packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
   slack-workflow-status:
-    if: ${{ always() && (github.repository_owner == 'WLAN-Pi') }}
+    if: ${{ always() && (github.repository_owner == 'WLAN-Pi') && (github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Post workflow status to Slack
     needs:
       - sbuild

--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -53,7 +53,7 @@ jobs:
         tox
 
   slack-workflow-status:
-    if: ${{ always() && (github.repository_owner == 'WLAN-Pi') }}
+    if: ${{ always() && (github.repository_owner == 'WLAN-Pi') && (github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Post Workflow Status to Slack
     needs:
       - python


### PR DESCRIPTION
This PR stops the GHA from trying to post to Slack when running a PR from a fork.

The secrets are not shared with PRs from forks and the job always fails.

`&& (github.event.pull_request.head.repo.full_name == github.repository)` should do the trick.