### PR TITLE
Handle when iptables rule is already removed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-wlanpi-core (1.0.5) unstable; urgency=high
+wlanpi-core (1.0.5-1) unstable; urgency=high
 
   * API hardening by blocking iptables rule added by pi-gen
 
- -- Josh Schmelzle <josh@joshschmelzle.com>  Sun, 27 Oct 2024 15:26:42 +0000
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Sun, 27 Oct 2024 14:55:42 -0400
 
 wlanpi-core (1.0.4) unstable; urgency=medium
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -46,8 +46,20 @@ if [ $CONF_CHANGED -eq 0 ]; then
 fi
 
 # Remove specific iptables rules added during pi-gen versions prior to v3.2.3
-echo "Removing old pi-gen iptables rules in WLAN Pi OS v3.2.2 and earlier"
-iptables -D ufw-user-input -p tcp --dport 31415 -j ACCEPT
-iptables -D ufw-user-input -p udp --dport 31415 -j ACCEPT
+echo "Attempting to remove old pi-gen iptables rules in WLAN Pi OS v3.2.2 and earlier"
+
+if iptables -C ufw-user-input -p tcp --dport 31415 -j ACCEPT 2>/dev/null; then
+    iptables -D ufw-user-input -p tcp --dport 31415 -j ACCEPT
+    echo "tcp 31415 rule removed."
+else
+    echo "tcp 31415 rule not found; no changes made."
+fi
+
+if iptables -C ufw-user-input -p udp --dport 31415 -j ACCEPT 2>/dev/null; then
+    iptables -D ufw-user-input -p udp --dport 31415 -j ACCEPT
+    echo "udp 31415 rule removed successfully."
+else
+    echo "udp 31415 rule not found; no changes made."
+fi
 
 exit 0


### PR DESCRIPTION
## Type of change 

* [X] Bug fix (non-breaking change that fixes something)

## Breaking change

*Does this Pull Request introduce a breaking change?* 

No 

## Proposed change

*Please describe the purpose of this change, the problem it solves, and why the change is necessary. Include code snippets or links to related documentation when applicable*

When iptables rule is already removed, such as when running WLAN Pi OS v3.2.3 or newer, we need to check if we can remove the rule before attempting to remove, otherwise error occurs preventing installation of wlanpi-core v1.0.5.

## Testing

*Please explain how you tested this change manually, and if applicable, what new tests you added.*

Manually tested.

## Checklist

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch
* [X] I have updated the changelog (if applicable)

## Related Issues/PRs 

- This PR is related to issue #50 