### PR TITLE
65 remove 3.11 from ci

### DIFF
--- a/.github/workflows/python-style-police.yml
+++ b/.github/workflows/python-style-police.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9"]
 
     steps:
     - name: Checkout

--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9"]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
## Type of change 

*Pick at least one.*

[x] Code quality improvement (refactor, performance improvements)
[x] Other (please specify): Resolving #65 

## Breaking change

*Does this Pull Request introduce a breaking change?* 
No

## Proposed change

This change resolves #65. I'm suggesting the approach of leaving the matrix function in but only keeping a single value for the moment. This should still allow the speedup until the transition period where both versions are needed without a refactor required on both ends.

## Testing

*Please explain how you tested this change manually, and if applicable, what new tests you added.*
CodeQL workflow [passed[(https://github.com/crvallance/wlanpi-core/actions/runs/11734477607) in my fork
Style police workflow [passed](https://github.com/crvallance/wlanpi-core/actions/runs/11734477596) in my fork
Test Python Package workflow [does not pass](https://github.com/crvallance/wlanpi-core/actions/runs/11734599467) but it doesn't appear to have been run or passed elsewhere either.

## Checklist

[x] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
[x] I have targeted this PR against the correct git branch
[ ] I ran the test suite and verified it succeeded
[x] I linked an approved GitHub issue to this PR (in the next section). No PR without a related GH issue. Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, and WLAN Pi Slack **do not count**.
[x] I have updated the changelog (if applicable)
[x] I have added or updated the documentation (if applicable)

## Related Issues/PRs

- This PR fixes/closes issue #65