### PR TITLE
Update getjwt.py to return non colorized output

### DIFF
--- a/wlanpi_core/cli/getjwt.py
+++ b/wlanpi_core/cli/getjwt.py
@@ -114,6 +114,11 @@ def main() -> int:
         default=DEFAULT_PORT,
         help=f"API port (default: {DEFAULT_PORT})",
     )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable colorized output",
+    )
 
     args = parser.parse_args()
 
@@ -121,15 +126,18 @@ def main() -> int:
         client = DeviceAuthClient(args.device_id, args.port)
         token_response = client.get_token()
         json_str = json.dumps(token_response, indent=2)
-        print(colorize_json(json_str))
+        if args.no_color:
+            print(json_str)
+        else:
+            print(colorize_json(json_str))
     except (FileNotFoundError, PermissionError) as e:
-        print(f"{RED}File Error: {str(e)}{NC}")
+        print(f"{prefix if args.no_color else f'{RED}{prefix}'} {str(e)}{'' if args.no_color else NC}")
         return 1
     except requests.RequestException as e:
-        print(f"{RED}API Error: {str(e)}{NC}")
+        print(f"{prefix if args.no_color else f'{RED}{prefix}'} {str(e)}{'' if args.no_color else NC}")
         return 1
     except Exception as e:
-        print(f"{RED}Unexpected Error: {str(e)}{NC}")
+        print(f"{prefix if args.no_color else f'{RED}{prefix}'} {str(e)}{'' if args.no_color else NC}")
         return 1
 
     return 0


### PR DESCRIPTION
Add --no-color to allow API to receive a usable output

## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [ x] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [ ] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Breaking change

<!-- *Does this Pull Request introduce a breaking change?* -->

- What functionality breaks?
- Why does it break?
- How should it be migrated?  
- Are there any backward-compatible alternatives?

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

Update getjwt.py to return non colorized output with the --no-color switch

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

- [No ] Did you add new automated tests? If yes, explain which edge cases are covered.
- [No] Does this change affect any existing tests? If so, how did you adjust them?
- [ ] Please provide test run results or screenshots if applicable.

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [x ] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [x] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #
- This PR is related to issue #
- This PR depends on/blocks PR #