### PR TITLE
Improve namespaces to handle non-present SSIDs and improve monitor mode handling

### DIFF
--- a/wlanpi_core/app.py
+++ b/wlanpi_core/app.py
@@ -37,7 +37,7 @@ from wlanpi_core.core.security import SecurityInitError, SecurityManager
 from wlanpi_core.core.system import SystemManager
 from wlanpi_core.core.token import TokenManager
 from wlanpi_core.services.system_service import get_model
-from wlanpi_core.utils.network_config import activate_config, get_current_config
+from wlanpi_core.utils.network_config import activate_config, get_current_config, interfaces_in_root
 from wlanpi_core.views.api import router as views_router
 
 

--- a/wlanpi_core/app.py
+++ b/wlanpi_core/app.py
@@ -26,6 +26,8 @@ from wlanpi_core.constants import (
     CURRENT_CONFIG_FILE,
     SECRETS_DIR,
     SUPPORTED_MODELS,
+    CREATE_MONITOR_PAIRS_DEFAULT,
+    CREATE_MONITOR_PAIRS_UNINIT,
 )
 from wlanpi_core.core.config import endpoints, settings
 from wlanpi_core.core.database import DatabaseError, DatabaseManager
@@ -330,12 +332,13 @@ class InitializationManager:
                     self.log.info(f"Default config activated sucessfully")
                     
                     
-                system_initialized = await self._initialize_system_manager("wlanpi")
-                if not system_initialized:
-                    self.log.error(
-                        "System manager initialization failed - cannot proceed"
-                    )
-                    return False
+                if CREATE_MONITOR_PAIRS_DEFAULT:
+                    system_initialized = await self._initialize_system_manager("wlanpi", exclusions=[])
+                    if not system_initialized:
+                        self.log.error(
+                            "System manager initialization failed - cannot proceed"
+                        )
+                        return False
             else:
                 model = get_model()
                 if model not in SUPPORTED_MODELS:
@@ -351,6 +354,14 @@ class InitializationManager:
                         
                     else:
                         self.log.info(f"Default config activated sucessfully")
+                                                
+                    if CREATE_MONITOR_PAIRS_DEFAULT:
+                        system_initialized = await self._initialize_system_manager("wlanpi", exclusions=[])
+                        if not system_initialized:
+                            self.log.error(
+                                "System manager initialization failed - cannot proceed"
+                            )
+                            return False
                 else:
                     self.log.info(
                         f"Activating current network configuration: {current_config}"
@@ -363,6 +374,15 @@ class InitializationManager:
                         )
                     else:
                         self.log.info(f"Config {current_config} activated sucessfully")
+                    
+                    if CREATE_MONITOR_PAIRS_UNINIT:
+                        exclusions = interfaces_in_root(current_config)
+                        system_initialized = await self._initialize_system_manager("wlanpi", exclusions=[])
+                        if not system_initialized:
+                            self.log.error(
+                                "System manager initialization failed - cannot proceed"
+                            )
+                            return False
 
         except FileNotFoundError:
             self.log.warning("No current network configuration found")
@@ -445,10 +465,10 @@ class InitializationManager:
             self.log.error(f"Token manager initialization failed: {e}")
             return False
 
-    async def _initialize_system_manager(self, iface_name: str):
+    async def _initialize_system_manager(self, iface_name: str, exclusions: list[str] = []):
         """Initialize the system manager"""
         try:
-            self.app.state.system_manager = SystemManager(iface_name)
+            self.app.state.system_manager = SystemManager(iface_name, exclusions=exclusions)
             self.log.debug("System manager initialized succcessfully")
             return True
         except Exception as e:

--- a/wlanpi_core/constants.py
+++ b/wlanpi_core/constants.py
@@ -59,6 +59,8 @@ CURRENT_CONFIG_FILE = "/home/wlanpi/.local/share/wlanpi-core/netcfg/current.txt"
 PID_DIR = "/home/wlanpi/.local/share/wlanpi-core/netcfg/pids"
 APPS_FILE = "/home/wlanpi/.local/share/wlanpi-core/netcfg/apps.json"
 WPA_LOG_FILE = "/tmp/wpa.log"
+CREATE_MONITOR_PAIRS_DEFAULT = True
+CREATE_MONITOR_PAIRS_UNINIT = True
 
 #### Paths below here are relative to script dir or /tmp fixed paths ###
 

--- a/wlanpi_core/core/system.py
+++ b/wlanpi_core/core/system.py
@@ -10,8 +10,9 @@ log = get_logger(__name__)
 
 
 class SystemManager:
-    def __init__(self, iface_name: str = "wlanpi"):
+    def __init__(self, iface_name: str = "wlanpi", exclusions: list[str] = []):
         self.iface_name = iface_name
+        self.exclusions = exclusions
         self.sync_monitor_interfaces()
 
     def _run(self, cmd, capture_output=False, suppress_output=False):
@@ -66,8 +67,10 @@ class SystemManager:
                 current_iface = line.strip().split()[1]
             elif "type" in line and current_iface:
                 iface_type = line.strip().split()[1]
-                interfaces[current_iface] = iface_type
-                current_iface = None
+                if current_iface not in self.exclusions:
+                    interfaces[current_iface] = iface_type
+                    current_iface = None
+                    
         return interfaces
 
     def _create_monitor(self, name, index):
@@ -134,6 +137,7 @@ class SystemManager:
                                 timeout=10
                             )
                             log.info(f"Scan on {iface} done")
+                            self._iface_up(expected_mon)
                             self._iface_down(iface)
                         except subprocess.TimeoutExpired:
                             log.warning(f"Scan on {iface} timed out after 10s")

--- a/wlanpi_core/core/system.py
+++ b/wlanpi_core/core/system.py
@@ -122,11 +122,12 @@ class SystemManager:
             expected_mon = f"{self.iface_name}{index}"
             if expected_mon not in monitor:
                 log.info(f"Creating monitor interface for {iface} → {expected_mon}")
+                self._iface_up(iface)
                 self._create_monitor(iface, index)
                 driver = self._get_driver(iface)
                 if driver == "iwlwifi":
+                    self._iface_up(expected_mon)
                     log.info(f"Bringing up and scanning on {iface}...")
-                    self._iface_up(iface)
                     def background_scan_with_timeout():
                         time.sleep(1)
                         try:
@@ -137,7 +138,7 @@ class SystemManager:
                                 timeout=10
                             )
                             log.info(f"Scan on {iface} done")
-                            self._iface_up(expected_mon)
+                            
                             self._iface_down(iface)
                         except subprocess.TimeoutExpired:
                             log.warning(f"Scan on {iface} timed out after 10s")

--- a/wlanpi_core/schemas/network/network.py
+++ b/wlanpi_core/schemas/network/network.py
@@ -70,6 +70,8 @@ class NetworkModeEnum(str, Enum):
 class SecurityTypes(str, Enum):
     wpa2 = "WPA2-PSK"
     wpa3 = "WPA3-PSK"
+    open = "OPEN"
+    owe = "OWE"
 
 
 class NetSecurity(BaseModel):

--- a/wlanpi_core/utils/network_config.py
+++ b/wlanpi_core/utils/network_config.py
@@ -62,6 +62,11 @@ def parse_iw_dev_output(output: str) -> dict:
 
     return interfaces
 
+def interfaces_in_root(cfg_id: str) -> list[str]:
+    cfg = get_config(cfg_id)
+    
+    root = cfg.roots or []
+    return [r.interface for r in root]
 
 def list_configs() -> dict[str, bool]:
     """List all configuration files in the CONFIG_DIR directory."""

--- a/wlanpi_core/utils/network_config.py
+++ b/wlanpi_core/utils/network_config.py
@@ -48,14 +48,15 @@ def parse_iw_dev_output(output: str) -> dict:
         if skip_table_block:
             continue
 
-        if ":" in stripped and not stripped.startswith("channel "):
-            key, value = map(str.strip, stripped.split(":", 1))
+        # Prefer splitting on the first whitespace to get the key token, then
+        # treat a leading ':' in the remainder as a key:value separator.
+        parts = stripped.split(None, 1)
+        if len(parts) == 2:
+            key, remainder = parts[0], parts[1]
         else:
-            parts = stripped.split(None, 1)
-            if len(parts) == 2:
-                key, value = parts
-            else:
-                key, value = parts[0], ""
+            key, remainder = parts[0], ""
+
+        value = remainder[1:].strip() if remainder.startswith(":") else remainder
 
         key = key.replace(" ", "_")
         interfaces[current_iface][key] = value

--- a/wlanpi_core/utils/network_config.py
+++ b/wlanpi_core/utils/network_config.py
@@ -157,7 +157,11 @@ def activate_config(cfg_id: str, override_active: bool = False) -> bool:
     """Activate a configuration by cfg_id."""
 
     cfg = get_config(cfg_id)
-    active_cfg = get_current_config()
+    try:
+        active_cfg = get_current_config()
+    except FileNotFoundError:
+        # Treat missing current-config as default (first-run scenario)
+        active_cfg = "default"
 
     if not override_active:
         if active_cfg != cfg_id and active_cfg != "default":
@@ -168,20 +172,41 @@ def activate_config(cfg_id: str, override_active: bool = False) -> bool:
         if active_cfg == cfg_id:
             raise ConfigActiveError(f"Configuration {cfg_id} is already active.")
     try:
+        if override_active:
+            log.info("Override active set: killing all wpa_supplicant processes before activation")
+            ns.kill_all_supplicants()
+        outcomes: list[str] = []
+
         for ns_cfg in cfg.namespaces or []:
             log.info(
                 f"Activating namespace {ns_cfg.namespace} for interface {ns_cfg.interface}"
             )
-            ns.activate_config(ns_cfg)
+            result = ns.activate_config(ns_cfg)
+            status = getattr(result, "status", "error") if result is not None else "error"
+            outcomes.append(status)
+
         for root_cfg in cfg.roots or []:
             log.info(f"Activating root config for interface {root_cfg.interface}")
-            ns.activate_config(root_cfg)
-        ccf.write_text(cfg_id)
-        return True
+            result = ns.activate_config(root_cfg)
+            status = getattr(result, "status", "error") if result is not None else "error"
+            outcomes.append(status)
+
+        # Determine if activation should be persisted
+        acceptable_statuses = {"connected", "provisioned"}
+        all_ok = all(status in acceptable_statuses for status in outcomes) if outcomes else True
+
+        if all_ok:
+            ccf.write_text(cfg_id)
+            return True
+        else:
+            log.error(f"Activation outcomes unacceptable {outcomes}. Rolling back and deactivating")
+            deactivate_config(cfg_id, override_active=True)
+            return False
 
     except Exception as ex:
-        log.error(f"Failed to activate config {cfg_id}: {ex}\nRolling back and deactivating")
-        deactivate_config(cfg_id, override_active=True)
+        # Do not roll back here; a provisioned (not connected) outcome should
+        # leave the configuration active. Only report the error upward.
+        log.error(f"Failed to activate config {cfg_id}: {ex}")
         raise
 
 
@@ -205,7 +230,8 @@ def deactivate_config(cfg_id: str, override_active: bool = False) -> bool:
             ns.deactivate_config(root_cfg)
 
         ccf.write_text("default")
-        activate_config("default", override_active=True)
+        # activate_config("default", override_active=True)
+        ns.revert_to_root(None)
         return True
 
     except Exception as ex:


### PR DESCRIPTION
## Type of change 

Bug fix + enhancement

<!-- *Pick at least one.* -->

* [x] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [x] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Breaking change

<!-- *Does this Pull Request introduce a breaking change?* -->

- What functionality breaks?
- Why does it break?
- How should it be migrated?  
- Are there any backward-compatible alternatives?

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

Namespaces was requiring the configuration of a WLAN connection to succeed in the moment for the configuration to be considered to have been correctly applied. DHCP was run early in the process too, before knowing if the interface was connected and this would hang for 15s. Upon failure it would then attempt to roll the configuration back. This was compounded by the fact that all this took longer than the nginx timeout so a 500 error was received.

This change re-orders the sequence of events and polls wpa_cli every second for 15 seconds after a wpa_supplicant config has been applied.  DHCP is then only started for interfaces in the connected state.

The previous two configuration outcomes were connected or error. Now this can be connected, provisioned or error.
Provisioned states return with success and wuickly bypass any attempts at DHCP

Cleanup code has been improved to ensure hanging wpa_supplicant daemon are removed and there is a clear revert function to get back to a default state with all adapters and interfaces in root namespace.

A fix for parsing of the interface MAC has also been applied.

While adapting the code, the insertion of the early bringup on mon mode has been added to comply with updated Intel guidance for LAR.

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

- [ ] Did you add new automated tests? If yes, explain which edge cases are covered.
- [ ] Does this change affect any existing tests? If so, how did you adjust them?
- [x] Please provide test run results or screenshots if applicable.

Tests were performed manually using postman and the WLAN Pi App. Tests creates which previously fail using a non present SSID now pass. The device can connect to that SSID later.

<img width="693" height="344" alt="image" src="https://github.com/user-attachments/assets/b96c39e2-07cf-4303-997c-d08501915ab8" />

<img width="644" height="501" alt="image" src="https://github.com/user-attachments/assets/5cb057c9-d9e5-4eec-8a90-bbc2c2d17456" />



## LLM/AI usage

<!-- *Please disclose any use of LLMs or AI coding assistants in creating this PR.* -->

- [x] I used an LLM or AI coding assistant for this PR
Cursor was used to provide assistance coding the the changes needed to fix the main bug where non-present SSIDs were causing an error. Cursor created the initial changes to network_namespace_service.py and network_config.py and adapt the 2 state return (connected, error) to a 3 state return (connected, provisioned, error). The code was adapted by hand thereafter to ensure fully working state.

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [x] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [x] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [x] I ran the test suite and verified it succeeded
* [x] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #106 
- This PR is related to issue #107 
- This PR depends on/blocks PR #