### PR TITLE
Add Subject Alternative Names to SSL certificate for Firefox compatibility

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-core (2.1.8-1) unstable; urgency=medium
+
+  * Add Subject Alternative Names to SSL certificate for Firefox compatibility
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Tue, 20 Jan 2026 23:04:54 -0500
+
 wlanpi-core (2.1.7-1) unstable; urgency=medium
 
   * chore: update Monitor mode bringup sequence for iwlwifi

--- a/debian/postinst
+++ b/debian/postinst
@@ -75,13 +75,37 @@ fi
 if [ ! -f /etc/nginx/ssl/self-signed-wlanpi.cert ] || [ ! -f /etc/nginx/ssl/self-signed-grafana.cert ] || [ ! -f /etc/cockpit/ws-certs.d/0-self-signed-wlanpi.cert ]; then
     mkdir -p /etc/nginx/ssl
     mkdir -p /etc/cockpit/ws-certs.d
+
+    cat > /tmp/wlanpi-ssl.cnf << 'EOF'
+[req]
+default_bits = 4096
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+CN = wlanpi.local
+O = wlanpi
+OU = wlanpi
+[v3_req]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = localhost
+DNS.2 = wlanpi.local
+IP.1 = 127.0.0.1
+IP.2 = 198.18.42.1
+EOF
     if ! openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 \
         -nodes -keyout /etc/nginx/ssl/self-signed-wlanpi.key \
         -out /etc/nginx/ssl/self-signed-wlanpi.cert \
-        -subj "/CN=wlanpi.local/O=wlanpi/OU=wlanpi"; then
+        -config /tmp/wlanpi-ssl.cnf -extensions v3_req; then
         echo "Error: Failed to generate SSL certificate"
+        rm -f /tmp/wlanpi-ssl.cnf
         exit 1
     fi
+    rm -f /tmp/wlanpi-ssl.cnf
     chmod 654 /etc/nginx/ssl/self-signed-wlanpi.cert
     chmod 650 /etc/nginx/ssl/self-signed-wlanpi.key
     /bin/cp /etc/nginx/ssl/self-signed-wlanpi.key /etc/cockpit/ws-certs.d/0-self-signed-wlanpi.key


### PR DESCRIPTION
## Summary

Enhances SSL certificate generation to include Subject Alternative Names (SAN), enabling Firefox to automatically trust the WLAN Pi from an upcoming local desktop GUI without manual certificate exceptions.

## Changes

- Updated `debian/postinst` to use OpenSSL config file with SAN extensions
- Added DNS entries for `localhost` and `wlanpi.local`
- Added IP entries for `127.0.0.1` and `198.18.42.1`
- Included proper v3 extensions for modern browser compatibility

## Why

Modern browsers, particularly Firefox, require certificates to include SAN (Subject Alternative Name) fields. The previous implementation only used the Common Name (CN) field via `-subj`, which Firefox no longer accepts for automatic trust.

<!-- *Pick at least one.* -->

* [ ] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [X] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [ ] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Breaking change

<!-- *Does this Pull Request introduce a breaking change?* -->

- What functionality breaks?
- Why does it break?
- How should it be migrated?  
- Are there any backward-compatible alternatives?

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

Tested locally.

## LLM/AI usage

<!-- *Please disclose any use of LLMs or AI coding assistants in creating this PR.* -->

- [X] I used an LLM or AI coding assistant for this PR
- If yes, please describe:
  - Which tool(s) and model(s) were used (e.g., Gemini 2.5 Flash, Claude 4.5 Sonnet, Copilot GPT-4, ChatGPT GPT-5)? Claude Sonnet 4.5
  - What portions of the code and PR were assisted?
  - Have you reviewed and tested all generated code for correctness?

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [ ] I linked a GitHub issue to this PR (in the next section). 
* [X] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #
- This PR is related to issue #
- This PR depends on/blocks PR #