### PR TITLE
Update wlanpi-core.service

### DIFF
--- a/debian/wlanpi-core.service
+++ b/debian/wlanpi-core.service
@@ -25,7 +25,7 @@ ExecStart=/opt/wlanpi-core/bin/gunicorn \
 ExecReload=/bin/kill -s HUP $MAINPID
 KillMode=mixed
 TimeoutStopSec=5
-PrivateTmp=true
+PrivateTmp=false
 
 # Restart=always
 Type=notify


### PR DESCRIPTION
updating PrivateTmp to false

## Summary

@bentumbler @joshschmelzle @crvallance I'm unsure if this is the right approach or if we should coordinate a change between lldp and core:

```
Is it safe to leave it as False?
For a single-purpose appliance like the WLAN Pi, the risk is extremely low. It's not a shared server with hundreds of users running arbitrary code.

However, if you want the "Perfect" Architectural Fix: If you want to turn PrivateTmp=true back on for maximum security in the future, the correct fix would be to change the LLDP daemon so that it stops writing to /tmp/lldpneigh.txt. Instead, it should write to a dedicated state directory (like /var/run/wlanpi/lldpneigh.txt or /etc/wlanpi-state/), which wlanpi-core is legally allowed to read regardless of the PrivateTmp setting!

```


The Issue: wlanpi-core reads LLDP from the /tmp/lldpneigh.txt file (which is actively populated by lldpd). However, the wlanpi-core.service systemd unit was configured with PrivateTmp=true. This is a systemd security feature that sandboxes the service so it literally can't see the real /tmp directory! Because wlanpi-core couldn't see the file, it assumed it didn't exist and returned an empty payload, resulting in FPMS2 displaying "No LLDP neighbours".

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

debian/wlanpi-core.service  set PrivateTmp=false.

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [X] I used AI/LLM assistance
- If yes: Tool(s) used:  Antigravity to find and identify the issue.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR fixes/closes issue #_128. fixes #128 

## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** 
- **Migration needed:** 
