### PR TITLE
Fix Trixie build consistency (#122) and support multi-suite builds

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9", "3.11", "3.13"]
 
     steps:
     - name: Checkout

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,8 +1,15 @@
 # Dockerfile for building wlanpi-core Debian package
-# Usage: podman build -f Dockerfile.build -t wlanpi-core-builder .
-#        podman run --rm -v $(pwd):/work -w /work wlanpi-core-builder
+#
+# Build for a specific Debian release (bullseye, bookworm, trixie) via SUITE:
+#   podman build -f Dockerfile.build --build-arg SUITE=trixie -t wlanpi-core-builder .
+#   podman run --rm -v $(pwd):/work -w /work wlanpi-core-builder
+#
+# Works with docker too (swap podman -> docker). The build-package-native.sh
+# helper auto-detects podman or docker and passes SUITE through for you.
 
-FROM debian:bookworm
+ARG SUITE=trixie
+
+FROM debian:${SUITE}
 
 # Note: cryptography 44.0.0+ typically requires Rust toolchain (cargo/rustc),
 # but we rely on pre-built wheels from piwheels.org (see requirements.txt)
@@ -16,7 +23,6 @@ RUN apt-get update && \
     python3 \
     python3-dev \
     python3-setuptools \
-    python3-distutils \
     python3-venv \
     dbus \
     libdbus-1-dev \

--- a/build-package-native.sh
+++ b/build-package-native.sh
@@ -1,28 +1,53 @@
 #!/bin/bash
 #
-# Build wlanpi-core Debian package in podman container
+# Build wlanpi-core Debian package in a container (podman or docker)
+#
+# Usage: ./build-package-native.sh [SUITE]
+#   SUITE   Debian release to build for: bullseye | bookworm | trixie (default: trixie)
+#
+# The container engine is auto-detected (podman preferred, then docker).
+# Override it explicitly with CONTAINER_ENGINE, e.g.:
+#   CONTAINER_ENGINE=docker ./build-package-native.sh trixie
 #
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Debian release to build for
+SUITE="${1:-trixie}"
+
+# Detect container engine (override with CONTAINER_ENGINE)
+if [ -n "$CONTAINER_ENGINE" ]; then
+    ENGINE="$CONTAINER_ENGINE"
+elif command -v podman &> /dev/null; then
+    ENGINE="podman"
+elif command -v docker &> /dev/null; then
+    ENGINE="docker"
+else
+    echo "ERROR: no container engine found!"
+    echo "Please install podman or docker (or set CONTAINER_ENGINE)."
+    exit 1
+fi
+
+if ! command -v "$ENGINE" &> /dev/null; then
+    echo "ERROR: container engine '$ENGINE' not found!"
+    exit 1
+fi
+
+IMAGE="wlanpi-core-builder:${SUITE}"
+
 # Clean up old build manifest
 rm -f .build-manifest.txt
 
 echo "========================================="
 echo "Building wlanpi-core Debian Package"
+echo "  engine: $ENGINE"
+echo "  suite:  $SUITE"
 echo "========================================="
 
-# Check for podman
-if ! command -v podman &> /dev/null; then
-    echo "ERROR: podman not found!"
-    echo "Please install podman to use this build script."
-    exit 1
-fi
-
-echo "Step 1: Building Docker image..."
-podman build -f Dockerfile.build -t wlanpi-core-builder .
+echo "Step 1: Building container image..."
+"$ENGINE" build -f Dockerfile.build --build-arg SUITE="$SUITE" -t "$IMAGE" .
 
 echo ""
 echo "Step 2: Building Debian package in container..."
@@ -30,10 +55,10 @@ echo "(This may take several minutes...)"
 echo ""
 
 # Run the build in container
-podman run --rm \
+"$ENGINE" run --rm \
     -v "$(pwd)":/work:Z \
     -w /work \
-    wlanpi-core-builder \
+    "$IMAGE" \
     bash -c '
 set -e
 

--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,7 @@ Section: contrib/python
 Priority: optional
 Maintainer: Josh Schmelzle <josh@joshschmelzle.com>
 Uploaders: 
-Build-Depends: debhelper (>= 11),
-               dh-python,
+Build-Depends: dh-python,
                dh-virtualenv (>= 1.2), 
                debhelper-compat (= 13),
                python3,
@@ -14,14 +13,14 @@ Build-Depends: debhelper (>= 11),
                dbus,
                libdbus-1-dev,
                libdbus-glib-1-dev
-Standards-Version: 4.6.0
+Standards-Version: 4.7.0
 X-Python3-Version: >= 3.9
 Homepage: https://github.com/WLAN-Pi/wlanpi-core
 
 Package: wlanpi-core
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.1), python3 (>=3.9), ${misc:Pre-Depends}
-Depends: ${misc:Depends}, ${shlibs:Depends}, dbus, lldpd, vlan, jc, sqlite3 (>= 3.34.0), sqlite3 (<< 3.41.2), nginx-light | nginx-full | nginx-extras, ufw, nftables, python3-gi, xxd
+Depends: ${misc:Depends}, ${shlibs:Depends}, dbus, lldpd, vlan, jc, sqlite3 (>= 3.34.0), nginx-light | nginx-full | nginx-extras, ufw, nftables, python3-gi, xxd
 Description: WLAN Pi - core backend services
  wlanpi-core provides API endpoints for various consumers on
  the WLAN Pi.

--- a/debian/rules
+++ b/debian/rules
@@ -53,13 +53,12 @@ override_dh_virtualenv:
 		--install-suffix "wlanpi-core" \
 		--builtin-venv \
 		--python ${SNAKE} \
-		--upgrade-pip-to=23.2 \
-		--preinstall="setuptools==65.5.0" \
-		--preinstall="wheel==0.37.1" \
+		--upgrade-pip-to=24.3.1 \
+		--preinstall="setuptools>=68" \
+		--preinstall="wheel>=0.43" \
 		--preinstall="mock" \
 		--extra-pip-arg "--no-cache-dir" \
-		--extra-pip-arg "--no-compile" \
-		--extras="testing"
+		--extra-pip-arg "--no-compile"
 	
 	$(DH_VENV_DIR)/bin/python $(DH_VENV_DIR)/bin/pip cache purge --verbose
 	$(DH_VENV_DIR)/bin/python $(DH_VENV_DIR)/bin/pip download $(DBUS_PYTHON_SPEC) --no-binary dbus-python ${DBUS_PYTHON_SPEC} --verbose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Development Status :: 1 - Planning",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: System Administrators",
     "Topic :: Utilities",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skip_missing_interpreters = true
-envlist = py39,py311
+envlist = py39,py311,py313
 requires = setuptools >= 65.5.0
            pip >= 22.3
            virtualenv >= 20.16.6


### PR DESCRIPTION
Debian packaging fixes for Trixie (debian/control, debian/rules):
- Remove broken sqlite3 (<< 3.41.2) upper bound (blocked install on Trixie)
- Drop redundant debhelper (>= 11) build-dep (implied by debhelper-compat 13)
- Bump Standards-Version 4.6.0 -> 4.7.0
- Update venv toolchain: pip 24.3.1, setuptools>=68, wheel>=0.43
- Drop --extras=testing so production builds exclude test deps

Note: pybuild buildsystem is intentionally kept (contrary to #122). A setup.py shim still exists, so without --buildsystem=pybuild dh falls back to the legacy python_distutils buildsystem and fails under compat 13.

Test infra now covers bullseye/bookworm/trixie (py39/py311/py313):
- pyproject.toml: add Python 3.13 classifier (Trixie ships 3.13, not 3.12)
- tox.ini envlist and CI matrix add py313/3.13

Container build supports docker and podman:
- Dockerfile.build: parameterize base image via SUITE arg; drop python3-distutils (absent on Trixie, shim provided by setuptools)
- build-package-native.sh: auto-detect podman/docker, accept SUITE arg

Verified by building wlanpi-core_2.1.10-2_arm64.deb both natively and in a debian:trixie container (python3.13 venv, no sqlite3 upper bound).

## Summary

<!-- Briefly describe the change and why it's needed -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [X] Other: Unblocking trixie builds. 

## Proposed change

Allows for versions that are installable directly on Debian trixie.

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [] Tested in another environment

## AI assistance

- [X] I used AI/LLM assistance
- If yes: Tool(s) used:  Claude Code to build and test.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR fixes/closes issue #_122 (or relates to issue #_)

## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** 
- **Migration needed:** 
