### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @joshschmelzle


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @joshschmelzle` so PRs automatically request review from the maintainer.

Part of the docs consistency pass tracked in the WLAN-Pi documentation review.