### PR TITLE
nginx: let JWT-bearing on-box clients reach the JWT auth path

### DIFF
--- a/install/etc/wlanpi-core/nginx/wlanpi_core.conf
+++ b/install/etc/wlanpi-core/nginx/wlanpi_core.conf
@@ -3,6 +3,17 @@ map $request_body $request_body_json {
     ""      "null";
 }
 
+# Clients that present their own wlanpi-core JWT (e.g. wlanpi-mcp) tag their
+# requests so nginx forwards a non-loopback X-Real-IP. That routes them to
+# core's JWT validator instead of the localhost HMAC path, which needs the
+# root-owned shared secret an unprivileged on-box service cannot read. This is
+# opt-in only: the JWT is still required and validated by core, so it can never
+# bypass auth, only demand a token where HMAC would otherwise apply.
+map $http_x_wlanpi_client $wlanpi_real_ip {
+    default   $remote_addr;
+    "mcp"     192.0.2.1;   # RFC 5737 TEST-NET-1 sentinel (non-loopback)
+}
+
 log_format json_combined escape=json
     '{'
     '"timestamp":"$time_iso8601",'
@@ -26,7 +37,7 @@ server {
 
     location / {
         proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $wlanpi_real_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_redirect off;


### PR DESCRIPTION
Localhost requests are routed to core's HMAC verifier (verify_auth_wrapper), which requires the root-owned shared secret. On-box services that hold a wlanpi-core JWT (e.g. wlanpi-mcp, which passes a client's Bearer token through) run unprivileged and cannot sign, so every call 401s.

Add an nginx map keyed on an X-Wlanpi-Client request header: tagged clients get a non-loopback sentinel X-Real-IP (192.0.2.1, RFC 5737), so is_localhost_request() is false and core validates their Bearer JWT instead. Opt-in and safe: the JWT is still required and validated, so this can only demand a token, never bypass auth. Untagged traffic keeps the existing $remote_addr behavior and HMAC path.

## Summary

<!-- What does this PR do and why? If it closes an issue, note it here: closes #123 --> Allows MCP server to tag its requests to allow core to force JWT even though the service is running locally.  without the tag, $remote_addr functions as normal.
<!-- If this introduces breaking changes, describe what breaks and what needs to migrate. --> No breaking changes

## Testing

<!-- How did you test this? --> Tested live on M4.

```
┌────────────────────┬──────┬────────────────┬────────────────────────────────────────────────────┐
│       Caller       │ Tag  │     Token      │                       Result                       │
├────────────────────┼──────┼────────────────┼────────────────────────────────────────────────────┤
│ Off-box (LAN)      │ none │ valid JWT      │ 200 — normal external path, unchanged              │
├────────────────────┼──────┼────────────────┼────────────────────────────────────────────────────┤
│ Off-box (LAN)      │ none │ none           │ 401                                                │
├────────────────────┼──────┼────────────────┼────────────────────────────────────────────────────┤
│ On-box (localhost) │ mcp  │ valid JWT      │ 200 — the fix                                      │
├────────────────────┼──────┼────────────────┼────────────────────────────────────────────────────┤
│ On-box (localhost) │ none │ valid JWT      │ 401 — HMAC path, unchanged (webui etc. unaffected) │
├────────────────────┼──────┼────────────────┼────────────────────────────────────────────────────┤
│ On-box (localhost) │ mcp  │ none / garbage │ 401 — no bypass                                    │
└────────────────────┴──────┴────────────────┴────────────────────────────────────────────────────┘
```

> AI assistance is welcome. Just make sure you have reviewed and tested what you are submitting. Large PRs take longer to review. Keep changes focused when you can.
