### PR TITLE
Bump to 2.1.10-3 to publish trixie packages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-core (2.1.10-3) unstable; urgency=medium
+
+  * Rebuild to publish packages for Debian trixie to packagecloud
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Thu, 09 Jul 2026 23:01:44 -0400
+
 wlanpi-core (2.1.10-2) unstable; urgency=medium
 
   * Hardening namespaces functionality for robustness and reliability


### PR DESCRIPTION
Rebuild so packagecloud wlanpi/dev gets a debian/trixie package — needed for the trixie image built from pi-gen-bookworm (wlanpi2-full stage).

The CI already includes trixie in its build matrix, but no trixie package exists on packagecloud for this repo. Where past deploys ran, they were green without anything landing in the dist index — the packagecloud CLI exits 0 on errors, so silent upload failures are invisible (and those logs have expired).

- This PR's changelog change triggers the PR build workflow as a bookworm + trixie test build.
- Merging triggers the packagecloud deploy.
- After merge, verify the package actually appears in https://packagecloud.io/wlanpi/dev/debian/dists/trixie/main/binary-arm64/Packages — a green run alone is not sufficient evidence given the exit-0 bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
