### PR TITLE
Fix trixie depends: unpin sqlite3, drop python3-distutils

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wlanpi-core (2.1.10-4) unstable; urgency=medium
+
+  * Remove sqlite3 upper version bound (uninstallable on trixie).
+  * Drop python3-distutils from Build-Depends and Pre-Depends (removed in
+    trixie; python3-setuptools provides it).
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Fri, 17 Jul 2026 17:11:43 -0400
+
 wlanpi-core (2.1.10-1) unstable; urgency=medium
 
   * Hardening namespaces functionality for robustness and reliability

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Build-Depends: debhelper (>= 11),
                python3,
                python3-dev, 
                python3-setuptools, 
-               python3-distutils, 
                python3-venv,
                dbus,
                libdbus-1-dev,
@@ -21,8 +20,8 @@ Homepage: https://github.com/WLAN-Pi/wlanpi-core
 
 Package: wlanpi-core
 Architecture: any
-Pre-Depends: dpkg (>= 1.16.1), python3 (>=3.9), python3-distutils, ${misc:Pre-Depends}
-Depends: ${misc:Depends}, ${shlibs:Depends}, dbus, lldpd, vlan, jc, sqlite3 (>= 3.34.0), sqlite3 (<< 3.41.2), nginx-light | nginx-full | nginx-extras, ufw, nftables, python3-gi, xxd
+Pre-Depends: dpkg (>= 1.16.1), python3 (>=3.9), ${misc:Pre-Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}, dbus, lldpd, vlan, jc, sqlite3 (>= 3.34.0), nginx-light | nginx-full | nginx-extras, ufw, nftables, python3-gi, xxd
 Description: WLAN Pi - core backend services
  wlanpi-core provides API endpoints for various consumers on
  the WLAN Pi.


### PR DESCRIPTION
Trixie install failure:

```
wlanpi-core : Depends: sqlite3 (< 3.41.2)
```

- Remove the `sqlite3 (<< 3.41.2)` upper bound (trixie ships 3.46.x). Floor `>= 3.34.0` kept.
- Drop `python3-distutils` from `Build-Depends` and `Pre-Depends` (removed in trixie; `python3-setuptools` provides it). Same fix as wlanpi-grafana#11 and wlanpi-ctx#3.
- `2.1.10-4` to supersede the published `2.1.10-3`.
