### PR TITLE
fix: don't clobber DHCP-assigned addresses in IPInterfaceAddress (#147)

### DIFF
--- a/tests/test_ip_interface_address_schema.py
+++ b/tests/test_ip_interface_address_schema.py
@@ -1,0 +1,59 @@
+import pytest
+from pydantic import ValidationError
+
+from wlanpi_core.schemas.network.network import IPInterfaceAddress
+
+
+def test_dynamic_address_keeps_real_ip():
+    # Regression for issue #147: `ip -j addr` marks DHCP-assigned addresses
+    # with dynamic=true; the validator must not clobber the parsed address.
+    addr = IPInterfaceAddress.model_validate(
+        {
+            "family": "inet",
+            "local": "10.254.102.42",
+            "prefixlen": 24,
+            "broadcast": "10.254.102.255",
+            "scope": "global",
+            "dynamic": True,
+            "label": "eth0",
+            "valid_life_time": 3600,
+            "preferred_life_time": 3600,
+        }
+    )
+
+    assert addr.local == "10.254.102.42"
+    assert addr.prefixlen == 24
+
+
+def test_dynamic_address_keeps_non_24_prefixlen():
+    addr = IPInterfaceAddress.model_validate(
+        {
+            "family": "inet",
+            "local": "172.16.5.9",
+            "prefixlen": 16,
+            "dynamic": True,
+        }
+    )
+
+    assert addr.local == "172.16.5.9"
+    assert addr.prefixlen == 16
+
+
+def test_dynamic_request_without_address_gets_placeholders():
+    # VLAN creation requests may omit local/prefixlen when asking for DHCP
+    addr = IPInterfaceAddress.model_validate({"family": "inet", "dynamic": True})
+
+    assert addr.local == "0.0.0.0"
+    assert addr.prefixlen == 24
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"family": "inet", "local": "10.0.0.1"},
+        {"family": "inet", "prefixlen": 24},
+    ],
+)
+def test_static_address_requires_local_and_prefixlen(payload):
+    with pytest.raises(ValidationError):
+        IPInterfaceAddress.model_validate(payload)

--- a/wlanpi_core/schemas/network/network.py
+++ b/wlanpi_core/schemas/network/network.py
@@ -47,8 +47,12 @@ class IPInterfaceAddress(BaseModel, extra=Extra.allow):
     def check_dynamic_condition(self) -> Any:
         # print(self)
         if self.dynamic:
-            self.prefixlen = 24
-            self.local = "0.0.0.0"
+            # Placeholders for DHCP requests; parsed `ip -j addr` output also
+            # sets dynamic=true and must keep its real address (issue #147)
+            if self.prefixlen is None:
+                self.prefixlen = 24
+            if self.local is None:
+                self.local = "0.0.0.0"
         else:
             if self.prefixlen is None:
                 raise ValueError("prefixlen required unless dynamic is True")


### PR DESCRIPTION
The check_dynamic_condition validator overwrote local/prefixlen with placeholders whenever dynamic=true. That's correct for VLAN creation requests asking for DHCP, but the same schema also validates parsed `ip -j addr` output, where dynamic=true marks a real DHCP-assigned address — so every DHCP interface (typically eth0) reported 0.0.0.0 and a forced /24 in API responses.

Only fill placeholders when the fields are missing, preserving parsed kernel output while keeping the request-side DHCP behavior.

## Summary

- Only adds placeholders if the values are missing, preventing overwriting of values.
- Fixes #147 