### PR TITLE
CI: test on Python 3.13 only, stable check names

### DIFF
--- a/.github/workflows/python-format-police.yml
+++ b/.github/workflows/python-format-police.yml
@@ -21,19 +21,15 @@ jobs:
   python-format-police:
     name: Python Format Police
     runs-on: "${{ vars.RUNS_ON || 'ubuntu-24.04' }}"
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9"]
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.13"
 
     - name: Install depends
       run: |

--- a/.github/workflows/python-lint-police.yml
+++ b/.github/workflows/python-lint-police.yml
@@ -21,19 +21,15 @@ jobs:
   python-lint-police:
     name: Python Lint Police
     runs-on: "${{ vars.RUNS_ON || 'ubuntu-24.04' }}"
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9"]
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.13"
 
     - name: Install depends
       run: |

--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -22,20 +22,17 @@ on:
 
 jobs:
   python:
-    runs-on: "ubuntu-22.04"
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9", "3.11"]
+    name: Python Tests
+    runs-on: "ubuntu-24.04"
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.13"
 
     - name: Install depends
       run: |

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
 skip_missing_interpreters = true
-envlist = py39,py311
-requires = setuptools == 65.5.0
-           pip == 22.3
-           virtualenv == 20.16.6
+envlist = py313
 
 [testenv]
 description = run the test driver 


### PR DESCRIPTION
- 3.9/3.11 are bullseye/bookworm pythons; trixie ships 3.13. Matrix is now 3.13 only.
- Dropped the single-item matrices and named the test job. Check contexts become `Python Tests`, `Python Format Police`, `Python Lint Police` with no version suffix, so branch protection stops rotting on python bumps (protection currently requires `Python Style Police (3.9)`/`(3.11)`, which no workflow produces, hence the permanently "Expected" checks).
- `checkout@v7`, `setup-python@v6`, `ubuntu-24.04`.
- tox: `envlist = py313`; removed the 2022 `requires` pins (pip 22.3 / virtualenv 20.16.6 do not support 3.13).

Branch protection required contexts will be updated to the three new names after merge. CI-only, no changelog bump.
