### PR TITLE
CI: stable version-agnostic check names

### DIFF
--- a/.github/workflows/python-format-police.yml
+++ b/.github/workflows/python-format-police.yml
@@ -21,19 +21,15 @@ jobs:
   python-format-police:
     name: Python Format Police
     runs-on: "${{ vars.RUNS_ON || 'ubuntu-26.04' }}"
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.13"]
 
     steps:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.13"
 
     - name: Install depends
       run: |

--- a/.github/workflows/python-lint-police.yml
+++ b/.github/workflows/python-lint-police.yml
@@ -21,19 +21,15 @@ jobs:
   python-lint-police:
     name: Python Lint Police
     runs-on: "${{ vars.RUNS_ON || 'ubuntu-26.04' }}"
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.13"]
 
     steps:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.13"
 
     - name: Install depends
       run: |

--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -22,20 +22,17 @@ on:
 
 jobs:
   python:
+    name: Python Tests
     runs-on: "ubuntu-26.04"
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.13"]
 
     steps:
     - name: Checkout
       uses: actions/checkout@v7
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.13"
 
     - name: Install depends
       run: |


### PR DESCRIPTION
Drops the single-item python matrices and names the test job. Check contexts become `Python Tests`, `Python Format Police`, `Python Lint Police` with no version suffix.

Why: branch protection on `main` was still requiring `Python Style Police (3.9)`/`(3.11)`, contexts nothing produces anymore, so every PR hung on Expected checks. Protection is now set to the three unsuffixed names; this PR makes the workflows emit exactly those, and future python bumps stop breaking protection.

Supersedes #149 (was wrongly based on main; dev already has the 3.13/runner/action updates).