### PR TITLE
docs: add missing jwt placeholder; fix sync workflow needs

### DIFF
--- a/.github/workflows/sync-openapi-reference.yml
+++ b/.github/workflows/sync-openapi-reference.yml
@@ -76,7 +76,7 @@ jobs:
     if: ${{ always() && (github.repository_owner == 'WLAN-Pi') && (! github.event.pull_request.head.repo.fork) }}
     name: Post Workflow Status to Slack
     needs:
-      - python-style-police
+      - regenerate
     runs-on: 'ubuntu-26.04'
     steps:
       - name: Slack Workflow Notification

--- a/wlanpi_core/api/openapi_docs.py
+++ b/wlanpi_core/api/openapi_docs.py
@@ -69,7 +69,7 @@ OPENAPI_TAGS: list[dict[str, str]] = [
         "name": "authentication",
         "description": (
             "JWT issuance and revocation. Remote clients authenticate once, "
-            "then send `Authorization: Bearer` on every request."
+            "then send `Authorization: Bearer <jwt>` on every request."
         ),
     },
     {


### PR DESCRIPTION
Two lines:

- The authentication tag description in `openapi_docs.py` read `Authorization: Bearer` with no placeholder. The generated `docs/openapi.json` reproduced it faithfully, which was mistaken in #145 for the exporter stripping `<jwt>`. The exporter (`json.dumps(app.openapi())`) cannot strip text; both `Bearer <jwt>` and `Bearer <token>` already survive export where the source has them. This adds the missing placeholder at the one spot that lacked it.
- `sync-openapi-reference.yml`'s Slack job had `needs: python-style-police`, a job that does not exist in that file, making the workflow invalid (its runs were failing). Point it at `regenerate`.

Once merged, the push to dev triggers the sync workflow and #145 refreshes with the corrected text. Nothing is hand-edited in `docs/openapi.json`.