### PR TITLE
tests: fix monitor harness races, tox py313 only, agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,13 @@ deterministic and warning-clean. Hard rules, each one from a real failure:
 6. **No hardware or network access.** Tests run offline on CI runners. Anything
    touching wpa_supplicant, iw, dbus, or subprocesses is mocked. Hardware
    verification happens on a WLAN Pi, not in unit tests.
-7. **Follow the matrix pattern.** Namespace scenarios live in
+7. **Patching `x.time.sleep` patches stdlib `time` globally.** Modules that do
+   plain `import time` all share the one `time` module object, so
+   `patch("wlanpi_core.connection.monitor.time.sleep")` also no-ops the test's
+   own `time.sleep` calls, turning polling loops into GIL-hogging busy-spins.
+   Synchronize with `threading.Event.wait` (blocks in C, unaffected by the
+   mock) instead of sleeping.
+8. **Follow the matrix pattern.** Namespace scenarios live in
    `tests/scenarios/*.csv` with handlers in `tests/test_namespace_matrix/`.
    Add scenarios there rather than writing parallel one-off tests.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# Guidance for coding agents
+
+Read this before changing code. It encodes lessons this codebase has already
+paid for. WORKFLOW.md covers setup, building, and releases.
+
+## Branch and PR rules
+
+- PRs target `dev` (the default branch). `main` is the release line; never PR it.
+- One concern per PR. One domain router, one fix, one refactor. No mixed
+  move-plus-change diffs. Soft cap ~400 changed lines.
+- CI-only or docs-only changes do not bump `debian/changelog`. A version bump
+  is a release; only package-content changes get one.
+
+## Writing tests
+
+The test suite runs on Python 3.13 only (`tox -e py313`). It must be
+deterministic and warning-clean. Hard rules, each one from a real failure:
+
+1. **No wall-clock polling of mock state.** Never loop on `mock.called` with a
+   deadline. Have the mock's `side_effect` set a `threading.Event` and wait on
+   that event. Assert after synchronization, not after a sleep.
+2. **Real threads need loud cleanup.** Any test that starts a monitor or
+   background thread must stop it and wait for it to actually die before the
+   test ends. Cleanup helpers must raise on timeout, never return silently: a
+   leaked thread consumes the next test's mocks and fails an unrelated test.
+3. **Patch where the code looks the name up.** If production does
+   `from x import y` at module top, patch it at the consuming module, not at
+   `x`. Lazy in-function imports are patched at the source module. Check the
+   import style before writing the patch target.
+4. **Shared mock sequences must be thread-safe.** A generator `side_effect`
+   consumed by more than one thread corrupts silently. Use a lock plus index.
+5. **Warning-clean or explicitly suppressed.** Tests that intentionally build
+   invalid models (e.g. via `model_construct`) must scope-suppress the expected
+   pydantic serializer warnings with `warnings.catch_warnings()` around the
+   exact call. Never suppress globally; never leave expected warnings in the
+   output, they bury real ones.
+6. **No hardware or network access.** Tests run offline on CI runners. Anything
+   touching wpa_supplicant, iw, dbus, or subprocesses is mocked. Hardware
+   verification happens on a WLAN Pi, not in unit tests.
+7. **Follow the matrix pattern.** Namespace scenarios live in
+   `tests/scenarios/*.csv` with handlers in `tests/test_namespace_matrix/`.
+   Add scenarios there rather than writing parallel one-off tests.
+
+## OpenAPI docs
+
+`docs/openapi.json` is generated (`scripts/export_openapi.py`) and maintained
+by the sync workflow. Never hand-edit it; fix the source docstrings or
+`openapi_docs.py` on `dev`. Placeholders like `<jwt>` in descriptions must sit
+inside backticks or Swagger UI swallows them as HTML tags.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+Read AGENTS.md before making changes. It contains the branch/PR rules and
+hard testing rules for this repository.

--- a/tests/test_namespace_matrix/handlers.py
+++ b/tests/test_namespace_matrix/handlers.py
@@ -5,6 +5,9 @@ activate_config persist vs rollback paths: tests/scenarios/ACTIVATION_OUTCOMES.m
 from __future__ import annotations
 
 import json
+import threading
+import time
+import warnings
 from pathlib import Path
 from unittest.mock import patch
 
@@ -115,7 +118,10 @@ def handle_validate_invalid_mode(namespace_service, netcfg_env, scenario: Scenar
         security=None,
         mlo=False,
     )
-    result = namespace_service.activate_config(cfg)
+    with warnings.catch_warnings():
+        # intentionally-invalid model; pydantic serializer warnings are expected
+        warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
+        result = namespace_service.activate_config(cfg)
     assert result.status == "error"
     assert "mode must be one of" in result.response.selectErr
 
@@ -171,7 +177,10 @@ def handle_validate_invalid_security_type(namespace_service, netcfg_env, scenari
         mlo=False,
         security=NetSecurity.model_construct(ssid="x", security="WEP-OLD", psk="x"),
     )
-    result = namespace_service.activate_config(cfg)
+    with warnings.catch_warnings():
+        # intentionally-invalid model; pydantic serializer warnings are expected
+        warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
+        result = namespace_service.activate_config(cfg)
     assert result.status == "error"
     assert "security.security must be one of" in result.response.selectErr
 
@@ -203,7 +212,10 @@ def handle_validate_default_route_non_bool(namespace_service, netcfg_env, scenar
         security=None,
         mlo=False,
     )
-    result = namespace_service.activate_config(cfg)
+    with warnings.catch_warnings():
+        # intentionally-invalid model; pydantic serializer warnings are expected
+        warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
+        result = namespace_service.activate_config(cfg)
     assert result.status == "error"
     assert "default_route must be a boolean" in result.response.selectErr
 
@@ -621,16 +633,33 @@ def handle_user_manual_phy_move_then_recover(namespace_service, netcfg_env, scen
 # --- connection monitor ---
 
 
-def _wait_for_monitors_idle(timeout_seconds: float = 3.0) -> None:
-    import time
+def _wait_for_monitors_idle(timeout_seconds: float = 5.0) -> None:
+    """Wait until no ConnectionMonitor registry entries or threads remain.
+
+    Fails loudly instead of returning silently: a leftover monitor thread from
+    one scenario keeps doing module-attribute lookups and consumes the next
+    scenario's mocks, which surfaces as unrelated flaky failures.
+    """
     from wlanpi_core.connection import monitor as mon
 
+    registry_empty = False
+    zombies: list[str] = []
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
         with mon._monitor_lock:
-            if not mon._connection_monitors:
-                return
+            registry_empty = not mon._connection_monitors
+        zombies = [
+            t.name
+            for t in threading.enumerate()
+            if t.name.startswith("ConnectionMonitor-") and t.is_alive()
+        ]
+        if registry_empty and not zombies:
+            return
         time.sleep(0.05)
+    raise RuntimeError(
+        f"ConnectionMonitor cleanup timed out: registry_empty={registry_empty}, "
+        f"zombie_threads={zombies}"
+    )
 
 
 def handle_ssid_delayed_connect_within_monitor(namespace_service, netcfg_env, scenario: Scenario):
@@ -650,26 +679,31 @@ def handle_ssid_delayed_connect_within_monitor(namespace_service, netcfg_env, sc
         {"wpa_status": {"wpa_state": "COMPLETED"}},
     ]
 
-    def wpa_side_effect():
-        pending = iter(status_sequence)
-        for item in pending:
-            yield item
-        while True:
-            yield {"wpa_status": {"wpa_state": "COMPLETED"}}
+    seq_lock = threading.Lock()
+    seq_state = {"i": 0}
 
-    with patch("wlanpi_core.connection.monitor.get_wpa_status", side_effect=wpa_side_effect()):
+    def wpa_side_effect(*args, **kwargs):
+        with seq_lock:
+            i = seq_state["i"]
+            seq_state["i"] = i + 1
+        if i < len(status_sequence):
+            return status_sequence[i]
+        return {"wpa_status": {"wpa_state": "COMPLETED"}}
+
+    app_started = threading.Event()
+
+    with patch("wlanpi_core.connection.monitor.get_wpa_status", side_effect=wpa_side_effect):
         with patch("wlanpi_core.connection.monitor.time.sleep"):
             with patch("wlanpi_core.connection.monitor.restart_dhcp_with_timeout") as dhcp:
                 with patch("wlanpi_core.connection.monitor.set_default_route"):
-                    with patch("wlanpi_core.namespaces.apps.start_app_in_namespace") as start_app:
+                    with patch(
+                        "wlanpi_core.namespaces.apps.start_app_in_namespace",
+                        side_effect=lambda *a, **k: app_started.set(),
+                    ) as start_app:
                         ConnectionMonitor.start_monitor(cfg, "wlan0", "ns_a", timeout=5)
-                        import time
-
-                        deadline = time.time() + 2
-                        while time.time() < deadline and not (
-                            dhcp.called and start_app.called
-                        ):
-                            time.sleep(0.01)
+                        assert app_started.wait(timeout=5), (
+                            "start_app_in_namespace not called within 5s"
+                        )
                         stop_all_connection_monitors()
                         _wait_for_monitors_idle()
     dhcp.assert_called_once()
@@ -678,6 +712,7 @@ def handle_ssid_delayed_connect_within_monitor(namespace_service, netcfg_env, sc
 
 def handle_ssid_delayed_beyond_monitor_timeout(namespace_service, netcfg_env, scenario: Scenario):
     stop_all_connection_monitors()
+    _wait_for_monitors_idle()
     cfg = _root(
         security=_security("VeryLateNet"),
         autostart_app="orb",
@@ -718,11 +753,17 @@ def handle_move_wlan1_to_ns_with_orb_monitor(namespace_service, netcfg_env, scen
 
 def handle_files_apps_json_missing_orb(namespace_service, netcfg_env, scenario: Scenario):
     """Missing orb in apps.json: monitor calls start_app; ValueError is caught gracefully."""
-    import time
-
     stop_all_connection_monitors()
     _wait_for_monitors_idle()
     cfg = _ns("orb_ns", interface="wlan1", phy="phy1", iface_display_name="wlan1", autostart_app="orb")
+    app_called = threading.Event()
+
+    def missing_app(*args, **kwargs):
+        try:
+            raise ValueError("App ID orb not found in apps file")
+        finally:
+            app_called.set()
+
     with patch(
         "wlanpi_core.connection.monitor.get_wpa_status",
         return_value={"wpa_status": {"wpa_state": "COMPLETED"}},
@@ -731,13 +772,13 @@ def handle_files_apps_json_missing_orb(namespace_service, netcfg_env, scenario: 
             with patch("wlanpi_core.connection.monitor.set_default_route"):
                 with patch(
                     "wlanpi_core.namespaces.apps.start_app_in_namespace",
-                    side_effect=ValueError("App ID orb not found in apps file"),
+                    side_effect=missing_app,
                 ) as start_app:
                     with patch("wlanpi_core.connection.monitor.time.sleep"):
                         ConnectionMonitor.start_monitor(cfg, "wlan1", "orb_ns", timeout=5)
-                        deadline = time.time() + 2
-                        while time.time() < deadline and not start_app.called:
-                            time.sleep(0.01)
+                        assert app_called.wait(timeout=5), (
+                            "start_app_in_namespace not called within 5s"
+                        )
                         stop_all_connection_monitors()
                         _wait_for_monitors_idle()
     start_app.assert_called_once_with("orb_ns", "orb")

--- a/tests/test_namespace_matrix/handlers.py
+++ b/tests/test_namespace_matrix/handlers.py
@@ -701,11 +701,12 @@ def handle_ssid_delayed_connect_within_monitor(namespace_service, netcfg_env, sc
                         side_effect=lambda *a, **k: app_started.set(),
                     ) as start_app:
                         ConnectionMonitor.start_monitor(cfg, "wlan0", "ns_a", timeout=5)
-                        assert app_started.wait(timeout=5), (
-                            "start_app_in_namespace not called within 5s"
-                        )
+                        app_ran = app_started.wait(timeout=5)
+                        # clean up BEFORE asserting so a failure cannot leak
+                        # a running monitor thread into the next test
                         stop_all_connection_monitors()
                         _wait_for_monitors_idle()
+    assert app_ran, "start_app_in_namespace not called within 5s"
     dhcp.assert_called_once()
     start_app.assert_called_once_with("ns_a", "orb")
 
@@ -776,11 +777,12 @@ def handle_files_apps_json_missing_orb(namespace_service, netcfg_env, scenario: 
                 ) as start_app:
                     with patch("wlanpi_core.connection.monitor.time.sleep"):
                         ConnectionMonitor.start_monitor(cfg, "wlan1", "orb_ns", timeout=5)
-                        assert app_called.wait(timeout=5), (
-                            "start_app_in_namespace not called within 5s"
-                        )
+                        app_ran = app_called.wait(timeout=5)
+                        # clean up BEFORE asserting so a failure cannot leak
+                        # a running monitor thread into the next test
                         stop_all_connection_monitors()
                         _wait_for_monitors_idle()
+    assert app_ran, "start_app_in_namespace not called within 5s"
     start_app.assert_called_once_with("orb_ns", "orb")
 
 

--- a/tests/test_namespace_matrix/handlers.py
+++ b/tests/test_namespace_matrix/handlers.py
@@ -726,8 +726,6 @@ def handle_ssid_delayed_beyond_monitor_timeout(namespace_service, netcfg_env, sc
             with patch("wlanpi_core.namespaces.apps.start_app_in_namespace") as start_app:
                 with patch("wlanpi_core.connection.monitor.time.sleep"):
                     ConnectionMonitor.start_monitor(cfg, "wlan0", None, timeout=15)
-                    import time
-
                     time.sleep(0.1)
                     stop_all_connection_monitors()
                     _wait_for_monitors_idle()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skip_missing_interpreters = true
-envlist = py39,py311,py313
+envlist = py313
 requires = setuptools >= 65.5.0
            pip >= 22.3
            virtualenv >= 20.16.6


### PR DESCRIPTION
Fixes the delayed-connect flake that failed CI on dev, plus cleanup.

## Root cause of the flake

Single-thread, no zombie required:

1. `patch("...monitor.time.sleep")` patches `sleep` on the **global stdlib `time` module** (monitor.py does plain `import time`), so the test's own `time.sleep(0.01)` poll loop was a no-op. Both the monitor thread and the test busy-spun on the GIL; on a loaded runner a ~2s stall could expire the old wall-clock deadline before the monitor reached the dhcp step.

2. `monitor_loop` pops itself from the registry **before** running the dhcp/route/app phase, and `stop_all_connection_monitors` holds `_monitor_lock` across its `join(2.0)` while the thread's own cleanup wants that lock: a guaranteed-timeout lock convoy that releases both threads simultaneously into patch teardown. The old `_wait_for_monitors_idle` watched only the registry and returned instantly.

3. The nested `with patch` blocks unwind innermost first: `start_app_in_namespace` is unpatched **before** `restart_dhcp_with_timeout`. The thread's dhcp call landed on the still-patched mock (1 call); its start_app call landed after restore (mock: 0 calls). Exactly the CI evidence: `dhcp called once, start_app called 0 times`.

## Changes

- `_wait_for_monitors_idle` requires the registry empty **and** no live `ConnectionMonitor-*` threads (they are already named), and raises on timeout instead of returning silently. This also closes the pop-before-actions blind spot.
- The three real-thread scenarios synchronize on a `threading.Event` set by the mock side_effect. `Event.wait` blocks in C and yields the GIL, so it is immune to the global sleep mock. Cleanup runs inside the patch stack and **before** assertions, so a failing run cannot tear down mocks under a live thread or leak one.
- The wpa status sequence is a locked index instead of a shared generator.
- The three intentionally-invalid validation scenarios scope-suppress their expected pydantic serializer warnings.
- tox `envlist = py313` only (py39/py311 were permanent SKIP noise; CI and the shipped target are 3.13).
- `AGENTS.md` with branch/PR and testing rules (including the global `time.sleep` aliasing gotcha), plus a `CLAUDE.md` pointer.

## Follow-ups (separate PRs)

- monitor.py: move registry cleanup to a `finally` after the action phase; stop holding `_monitor_lock` across `join()`.
- pyproject.toml: stale `requires-python = ">=3.9"` and 3.9/3.11 classifiers.
