### PR TITLE
pyproject: require Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "wlanpi-core"
 description = "backend services for the WLAN Pi"
-requires-python = ">=3.9"
+requires-python = ">=3.13"
 dynamic = ["version"]
 authors = [
     {name = "Josh Schmelzle", email = "josh@joshschmelzle.com"},
@@ -13,8 +13,6 @@ authors = [
 classifiers = [
     "Natural Language :: English",
     "Development Status :: 1 - Planning",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.13",
     "Intended Audience :: System Administrators",
     "Topic :: Utilities",


### PR DESCRIPTION
Housekeeping from the #152 audit: `requires-python = ">=3.9"` and the 3.9/3.11 classifiers were stale. The package targets trixie only (debian `Pre-Depends: python3 (>= 3.13)`, CI and tox test 3.13 only). Now `>=3.13` with the single matching classifier.