### PR TITLE
First-boot initialization hardening + systemd/packaging fixes

### DIFF
--- a/debian/prerm
+++ b/debian/prerm
@@ -3,9 +3,10 @@ set -e
 
 case "$1" in
     remove|upgrade|deconfigure)
-        # Try to unmount gracefully first
-        if systemctl is-active wlanpi-core-debug.mount >/dev/null 2>&1; then
-            systemctl stop wlanpi-core-debug.mount || true
+        # Try to unmount gracefully first (correct unit name is
+        # var-log-wlanpi_core-debug.mount, not wlanpi-core-debug.mount)
+        if systemctl is-active var-log-wlanpi_core-debug.mount >/dev/null 2>&1; then
+            systemctl stop var-log-wlanpi_core-debug.mount || true
         fi
         # Force unmount if still mounted
         if mountpoint -q /var/log/wlanpi_core/debug; then
@@ -19,5 +20,10 @@ case "$1" in
         exit 1
     ;;
 esac
+
+# dh_installsystemd injects the systemctl stop/disable for wlanpi-core.service
+# and wlanpi-core.socket here. Without this token the units were never stopped
+# on removal.
+#DEBHELPER#
 
 exit 0

--- a/debian/wlanpi-core.install
+++ b/debian/wlanpi-core.install
@@ -10,3 +10,4 @@
 /install/etc/wlanpi-core/ufw/current-rules-version /etc/wlanpi-core/ufw
 /install/etc/wpa_supplicant/wpa_supplicant-wlan0.conf /etc/wpa_supplicant
 /install/usr/bin/lhapitest /usr/bin
+/install/usr/bin/wlanpi-core-preflight /usr/bin

--- a/debian/wlanpi-core.service
+++ b/debian/wlanpi-core.service
@@ -43,6 +43,7 @@ ExecStart=/opt/wlanpi-core/bin/gunicorn \
 ExecReload=/bin/kill -s HUP $MAINPID
 KillMode=mixed
 TimeoutStopSec=5
+TimeoutStartSec=30
 PrivateTmp=false
 
 # Restart on failed startup (now that critical-init failures fail the lifespan)

--- a/debian/wlanpi-core.service
+++ b/debian/wlanpi-core.service
@@ -5,6 +5,17 @@ Description=gunicorn daemon which manages uvicorn workers for wlanpi-core
 Wants=nginx.service
 Requires=wlanpi-core.socket var-log-wlanpi_core-debug.mount
 After=network-pre.target var-log-wlanpi_core-debug.mount nginx.service
+# Refuse to start until the filesystems backing our state and logs are mounted.
+# A0 keeps the current state paths; the path flip to /home/wlanpi-core is a
+# later PR. On a single-partition image these resolve to the (always-present)
+# root mount and are harmless no-ops; on split partitions they add correct
+# ordering.
+RequiresMountsFor=/home/wlanpi /var/log/wlanpi_core
+# Bound restart attempts so a permanently-failing start (e.g. a genuine
+# security-init failure that now fails the lifespan) cannot tight-loop forever.
+# StartLimit* belong in [Unit], not [Service].
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=notify
@@ -12,10 +23,17 @@ Type=notify
 # this is a soft link created via maintainer script
 WorkingDirectory=/opt/wlanpi-core/workingdirectory
 
+# Fail fast if the state directory is not writable before we launch workers.
+ExecStartPre=/usr/bin/wlanpi-core-preflight
+
+# Bind the absolute socket path that the socket unit (ListenStream) and the
+# nginx proxy_pass (unix:/run/wlanpi_core.sock) both use. The previous relative
+# "unix:wlanpi_core.sock" resolved under WorkingDirectory to a DIFFERENT socket
+# than the one nginx connects to.
 ExecStart=/opt/wlanpi-core/bin/gunicorn \
     --workers 1 \
     -k uvicorn.workers.UvicornWorker \
-    --bind unix:wlanpi_core.sock asgi:app \
+    --bind unix:/run/wlanpi_core.sock asgi:app \
     --name wlanpi_core_svc \
     --access-logfile /var/log/wlanpi_core/gunicorn_access.log \
     --error-logfile /var/log/wlanpi_core/gunicorn_error.log \
@@ -27,8 +45,11 @@ KillMode=mixed
 TimeoutStopSec=5
 PrivateTmp=false
 
-# Restart=always
-Type=notify
+# Restart on failed startup (now that critical-init failures fail the lifespan)
+# and on worker crashes, so a transient first-boot failure self-heals via a full
+# process restart. Bounded by StartLimit* in [Unit] above.
+Restart=on-failure
+RestartSec=2
 NotifyAccess=all
 
 [Install]

--- a/debian/wlanpi-core.socket
+++ b/debian/wlanpi-core.socket
@@ -1,4 +1,4 @@
-# wlanpi-webui.socket
+# wlanpi-core.socket
 
 [Unit]
 Description=wlanpi-core gunicorn socket

--- a/install/usr/bin/wlanpi-core-preflight
+++ b/install/usr/bin/wlanpi-core-preflight
@@ -1,0 +1,40 @@
+#!/bin/sh
+# wlanpi-core-preflight
+#
+# ExecStartPre writable probe for wlanpi-core. Fails (non-zero exit) if the
+# state directory backing our secrets/token database is not writable, so the
+# service refuses to start rather than coming up half-initialized. systemd's
+# restart policy then retries (bounded by StartLimit*), which papers over the
+# transient first-boot filesystem races that make early writes fail.
+#
+# NOTE: a .service ExecStartPre cannot import Python constants, so these paths
+# are duplicated from wlanpi_core/constants.py (SECRETS_DIR). A0 keeps the
+# CURRENT paths under /home/wlanpi; the flip to /home/wlanpi-core is a later PR
+# and must update this script in lockstep.
+
+set -eu
+
+# Keep in sync with wlanpi_core.constants.SECRETS_DIR
+STATE_DIR="/home/wlanpi/.local/share/wlanpi-core/secrets"
+
+fail() {
+    echo "wlanpi-core-preflight: FATAL: $1" >&2
+    exit 1
+}
+
+# Create the tree if missing (mkdir -p is idempotent). SecurityManager also
+# does this in-process, but doing it here lets the probe below be meaningful on
+# a truly fresh boot.
+mkdir -p "$STATE_DIR" 2>/dev/null || fail "cannot create state directory $STATE_DIR"
+
+[ -d "$STATE_DIR" ] || fail "state directory $STATE_DIR does not exist"
+
+# Verify we can actually write+read+remove in the state directory.
+PROBE="$STATE_DIR/.preflight_$$"
+if ! ( : > "$PROBE" ) 2>/dev/null; then
+    fail "state directory $STATE_DIR is not writable"
+fi
+rm -f "$PROBE" 2>/dev/null || true
+
+echo "wlanpi-core-preflight: state directory $STATE_DIR is writable"
+exit 0

--- a/install/usr/bin/wlanpi-core-preflight
+++ b/install/usr/bin/wlanpi-core-preflight
@@ -25,7 +25,7 @@ fail() {
 # Create the tree if missing (mkdir -p is idempotent). SecurityManager also
 # does this in-process, but doing it here lets the probe below be meaningful on
 # a truly fresh boot.
-mkdir -p "$STATE_DIR" 2>/dev/null || fail "cannot create state directory $STATE_DIR"
+mkdir -p -m 0700 "$STATE_DIR" 2>/dev/null || fail "cannot create state directory $STATE_DIR"
 
 [ -d "$STATE_DIR" ] || fail "state directory $STATE_DIR does not exist"
 

--- a/wlanpi_core/app.py
+++ b/wlanpi_core/app.py
@@ -224,6 +224,16 @@ class ApplicationHealthManager:
                         self.log.error(f"Failed to recover token manager: {e}")
 
 
+class CriticalInitializationError(RuntimeError):
+    """Raised when a critical component fails to initialize.
+
+    Critical init failures must abort the ASGI lifespan ("fully initialized or
+    it doesn't start") so gunicorn/uvicorn report a failed startup and systemd
+    can detect it and apply its restart policy, rather than the service coming
+    up half-initialized and serving broken auth-protected routes.
+    """
+
+
 class InitializationManager:
     """
     Manager for application initialization with retry mechanisms
@@ -232,6 +242,10 @@ class InitializationManager:
     def __init__(self, app):
         self.app = app
         self.max_retries = 3
+        # Base delay (seconds) for the security-init retry backoff. Without this
+        # attribute the retry path raised AttributeError before it could retry,
+        # defeating the whole retry loop on the very first failure.
+        self.initial_retry_delay = 2.0
         self.log = get_logger(__name__)
         self.initialized = False
 
@@ -431,10 +445,18 @@ class InitializationManager:
             self.log.error(f"Unexpected error during network namespace initialization: {e} (non-critical, continuing)", exc_info=True)
 
     async def initialize_components(self):
-        """Initialize all application components with proper sequencing and retry"""
+        """Initialize all application components with proper sequencing and retry.
+
+        Critical components (system readiness, security, database) must succeed
+        or this raises CriticalInitializationError to fail the ASGI lifespan.
+        Non-critical components (token manager) degrade to limited functionality
+        without aborting startup.
+        """
         if not await self.check_system_readiness():
             self.log.error("System not ready for initialization")
-            return False
+            raise CriticalInitializationError(
+                "System not ready for initialization"
+            )
 
         # Initialize network namespaces (non-blocking - failures don't stop core)
         await self._initialize_network_namespaces()
@@ -442,23 +464,26 @@ class InitializationManager:
         security_initialized = await self._initialize_security_manager()
         if not security_initialized:
             self.log.error("Security initialization failed - cannot proceed")
-            return False
+            raise CriticalInitializationError(
+                "Security manager initialization failed"
+            )
 
         database_initialized = await self._initialize_database()
         if not database_initialized:
             self.log.error(
                 "Database initialization failed - cannot proceed with token management"
             )
-            self.initialized = True
-            return True
+            raise CriticalInitializationError(
+                "Database initialization failed"
+            )
 
         token_initialized = await self._initialize_token_manager()
         if not token_initialized:
+            # Token manager is not critical: the service can start with reduced
+            # functionality. Do not abort the lifespan for this.
             self.log.warning(
                 "Token manager initialization failed - some functionality will be limited"
             )
-            self.initialized = True
-            return True
 
         self.initialized = True
         self.log.info("All components initialized ...")
@@ -655,15 +680,15 @@ def create_app(debug: bool = False):
         app.state.initialization_manager = InitializationManager(app)
         app.state.health_manager = ApplicationHealthManager(app)
 
-        initialization_success = (
-            await app.state.initialization_manager.initialize_components()
-        )
+        # A critical-init failure raises CriticalInitializationError, which is
+        # allowed to propagate out of the startup handler so the ASGI lifespan
+        # fails. gunicorn/uvicorn then report a failed startup and systemd's
+        # restart policy takes over, rather than the service coming up
+        # half-initialized and serving broken auth-protected routes.
+        await app.state.initialization_manager.initialize_components()
 
-        if initialization_success:
-            log.info("Application successfully initialized")
-            await app.state.health_manager.start_health_checks()
-        else:
-            log.error("Application initialization failed")
+        log.info("Application successfully initialized")
+        await app.state.health_manager.start_health_checks()
 
     @app.on_event("shutdown")
     async def shutdown():

--- a/wlanpi_core/core/database.py
+++ b/wlanpi_core/core/database.py
@@ -153,7 +153,7 @@ class DatabaseManager:
                     str(e),
                 )
                 if attempt < max_retries:
-                    self.log.info("Retrying in %d seconds...", retry_delay)
+                    log.info("Retrying in %d seconds...", retry_delay)
                     await asyncio.sleep(retry_delay)
                     retry_delay = min(retry_delay * 2, 5)
 


### PR DESCRIPTION
## Summary

Fix a first-boot initialization failure and clean up the systemd unit + Debian maintainer scripts.

This effort does NOT include the state move to `/home/wlanpi-core`, auth rework, or root-only perms.

## Changes

**Core**

- `app.py`: define `InitializationManager.initial_retry_delay` (was undefined -> `AttributeError` crashed the security-init retry before it retried).
- `app.py`: fail loud on critical init — readiness/security/database failures now raise `CriticalInitializationError` and fail the ASGI lifespan instead of logging and continuing (previously db/token failures set `initialized=True` and returned success). Token-manager failure stays non-fatal (limited functionality; health loop recovers).
- `database.py`: fix undefined `self.log` -> module-level `log` in `initialize_with_retry`.

**systemd / Debian**

- `wlanpi-core.service`: remove duplicate `Type=notify`; add `Restart=on-failure` + `RestartSec=2` + `StartLimitIntervalSec=60`/`StartLimitBurst=5` (finite burst so a permanent failure can't tight-loop) + `TimeoutStartSec=30`; `RequiresMountsFor` for the current state paths; `ExecStartPre` writability probe.
- New `install/usr/bin/wlanpi-core-preflight` helper (probes the state dir is writable; creates it 0700) wired into `debian/wlanpi-core.install`.
- `wlanpi-core.socket`: fix stale header comment.
- Reconcile the gunicorn socket bind (relative -> absolute `/run/wlanpi_core.sock`) so it matches nginx `proxy_pass` and the socket unit.
- `debian/prerm`: fix wrong mount-unit name (`var-log-wlanpi_core-debug.mount`) and add `#DEBHELPER#` so the service/socket are stopped on removal.

## Testing

- `pytest -q`: 400 passed, 20 skipped, 0 failures.
- Note: the existing suite monkeypatches `initialize_components`, so the fail-loud/retry paths aren't exercised by app-level tests: TODO: follow-up to add real unit tests.

## Validation this PR should exercise

- Debian package build + `lintian` + `systemd-analyze verify`.
- (Manual, off-CI) first-boot test on a real Pi: crash -> restart -> recover; socket + preflight behavior.

## Follow-ups

- #156 — move cross-process `/tmp` handoffs to `/run` and enable `PrivateTmp=true`.
- Add fail-loud/retry unit tests (bypass the `mock_app_initialization` autouse fixture).
- Reconcile socket dual-start (`multi-user.target` + socket activation).
