### PR TITLE
Capture WebSocket first-message auth and owned sessions (P6 / #141)

### DIFF
--- a/docs/API-INTEGRATION-GUIDE.md
+++ b/docs/API-INTEGRATION-GUIDE.md
@@ -365,51 +365,90 @@ Blinker runs until stopped (cable-finder LED pattern on Ethernet).
 
 **Endpoint:** `WS /api/v1/streaming/capture`
 
-### Workflow
+Live Wi-Fi capture: send JSON **text** commands, receive JSON **events** and
+binary **pcapng** frames. One authenticated connection owns a capture; other
+authenticated connections can subscribe to it read-only.
 
-1. Open WebSocket (no auth today — privileged operation).
-2. Send JSON commands as **text** frames.
-3. Receive JSON **events** and binary **pcapng** data.
+> Through nginx the URL is `wss://<host>/api/v1/streaming/capture` on the TLS
+> front-end, or `ws://<host>:31415/...` on the plain port. Tokens go in the
+> first message, **never** in the URL (query strings are logged; a `?token=`
+> connection is refused with close code 4401).
 
-### Commands
+### 11.1 Authenticate (first message, required)
+
+The first frame MUST authenticate within 10 seconds, or the socket closes with
+code **4401**:
 
 ```json
-{ "command": "get_supported_frequencies" }
+{ "command": "auth", "token": "<core JWT from Lesson 1>" }
+```
+
+Reply: `{"type":"event","event":"status","code":"AUTH_OK","data":{"did":"…"}}`.
+An invalid/expired token, a non-auth first message, or a timeout closes 4401.
+
+### 11.2 Own a capture
+
+```json
+{ "command": "configure",
+  "interfaces": { "wlanpi0": { "channels": [{"freq": 5180, "width": 20}],
+                               "dwell_time": 250 } } }
 ```
 
 ```json
-{
-  "command": "configure",
-  "interfaces": {
-    "wlanpi0": { "channels": [36, 40, 44], "dwell": 250 }
-  }
-}
+{ "command": "start", "interfaces": ["wlanpi0"], "pcap_filter": "" }
 ```
+
+`width` ∈ {20,40,80,160}; `dwell_time` 50–60000 ms. Interface names are the
+monitor VIFs (`wlanpiN`); core runs the capture in whatever namespace the
+adapter lives in. `start` replies `CAPTURE_STARTED` with a `session_id`
+(`cap_xxxx`), the `interfaces`, the `namespace`, and the running `config`.
+Then binary pcapng frames stream until `{ "command": "stop" }`, the socket
+closes, or the capture ends (`CAPTURE_ENDED`). Only the owning connection can
+`configure`/`stop`.
+
+### 11.3 Subscribe to someone else's capture (read-only)
+
+Discover running captures, then attach — you do **not** need the owner's
+command or `session_id` in advance:
 
 ```json
-{
-  "command": "start",
-  "interfaces": ["wlanpi0"],
-  "pcap_filter": ""
-}
+{ "command": "list_sessions" }
 ```
+
+Reply `SESSIONS` lists each capture with `session_id`, `owner`, `interfaces`,
+`namespace`, and `config`. Pick the one on the interface you want (one owner
+per interface) and:
 
 ```json
-{ "command": "stop" }
+{ "command": "subscribe", "session_id": "cap_ab12cd34" }
 ```
 
-### Event shape (simplified)
+`SUBSCRIBED` returns that session's `config` (so you know the channels/filter
+you are receiving), then the same binary pcapng stream arrives. A subscriber
+cannot control the capture; `{ "command": "unsubscribe" }` detaches. When the
+owner stops or disconnects, subscribers get `CAPTURE_STOPPED`/`CAPTURE_ENDED`.
+
+### 11.4 Other commands & events
+
+`{ "command": "get_supported_frequencies" }` → `SUPPORTED_FREQUENCIES` (channel
+list per capture adapter). Event shape:
 
 ```json
-{
-  "type": "event",
-  "category": "error",
-  "code": "UNKNOWN_COMMAND",
-  "message": "Unsupported command: foo"
-}
+{ "type": "event", "event": "status", "code": "CAPTURE_STARTED",
+  "data": { "session_id": "cap_ab12", "interfaces": ["wlanpi0"],
+            "namespace": null, "config": { … } } }
 ```
 
-**Planned:** REST session API with token-gated subscriber WebSocket — see `docs/P0-wifi-capture-api.md` (design only).
+Notable codes: `AUTH_OK`, `AUTH_FAILED`, `CAPTURE_STARTED`, `CHANNEL_SET` /
+`CHANNEL_SET_FAILED` (hop status; the failure message carries the `iw` reason —
+on single-radio devices the phy can be briefly busy while the managed interface
+scans), `SUBSCRIBED`, `SESSIONS`, `UNSUBSCRIBED`, `CAPTURE_STOPPED`,
+`CAPTURE_ENDED`, and errors `INTERFACE_IN_USE`, `INTERFACE_NOT_AVAILABLE`,
+`SESSION_NOT_FOUND`, `CONFIG_INVALID`, `UNKNOWN_COMMAND`.
+
+**Reference client:** `tools/capture_harness/` implements this whole flow
+(owner, subscriber-by-interface, and pcapng dissection). **MCP integration:**
+`docs/capture-ws-mcp-handover.md`.
 
 ---
 

--- a/docs/capture-ws-mcp-handover.md
+++ b/docs/capture-ws-mcp-handover.md
@@ -1,0 +1,192 @@
+# Handover: WiFi packet capture over the core WebSocket → wlanpi-mcp
+
+**Audience:** whoever adds packet-capture tools to wlanpi-mcp (and the coding
+agents they drive). **Prereq reading:** the auth plan (`docs/mcp-auth-plan.md`)
+and its Appendix A. **Reference client:** `tools/capture_harness/` in this repo
+implements everything below and is worth reading as a worked example.
+
+This describes a **finished, tested** core capability and how MCP should consume
+it. The core side is done on branch `feature/capture-auth`; nothing here asks
+for core changes.
+
+---
+
+## 1. What core provides
+
+A single WebSocket endpoint:
+
+```
+ws://<host>:31415/api/v1/streaming/capture      (plain, current)
+wss://<host>:.../api/v1/streaming/capture       (TLS - see §6, not yet through nginx)
+```
+
+It authenticates per-connection, runs one owned capture per socket, streams
+**pcapng** binary frames, and lets other authenticated connections **subscribe
+read-only** to a running capture. There is no REST capture API; this WebSocket
+is the interface.
+
+### Message protocol
+
+All client→server messages are JSON text. The **first** message MUST be auth:
+
+```json
+{"command": "auth", "token": "<core JWT>"}
+```
+
+Server replies `AUTH_OK` (or closes with code **4401** on failure / a 10s
+timeout / a token in the URL). After that:
+
+| Command | Payload | Notes |
+|---|---|---|
+| `get_supported_frequencies` | `{}` | channel list the device supports |
+| `configure` | `{"interfaces": {"wlanpi0": {"channels": [{"freq": 2412, "width": 20}], "dwell_time": 250}}}` | per-interface config; `width` ∈ {20,40,80,160}, `dwell_time` 50–60000 ms |
+| `start` | `{"interfaces": ["wlanpi0"], "pcap_filter": ""}` | begins capture; interfaces must be configured first |
+| `stop` | `{}` | owner only |
+| `subscribe` | `{"session_id": "cap_xxxx"}` | listen read-only to another socket's capture |
+| `unsubscribe` | `{}` | detach |
+| `list_sessions` | `{}` | enumerate running captures |
+
+Interface names must match `wlanpiN` (the monitor-mode interface), not `wlan0`.
+
+### Server→client messages
+
+- **Binary frames** = pcapng bytes (multiplexed if multiple interfaces). These
+  arrive in unaligned chunks; buffer and parse pcapng blocks incrementally.
+- **Text events** = `{"type","event","code","data"}`. Key codes:
+  `AUTH_OK` (`data.did`), `CAPTURE_STARTED` (`data.session_id`,
+  `data.interfaces`), `CHANNEL_SET` / `CHANNEL_SET_FAILED` (hop status; failure
+  `data.message` carries the `iw` reason), `SUBSCRIBED`, `SESSIONS`
+  (`data.sessions`), `CAPTURE_STOPPED` / `CAPTURE_ENDED`, and `error` events
+  (`AUTH_FAILED`, `INTERFACE_IN_USE`, `SESSION_NOT_FOUND`, `CONFIG_INVALID`, …).
+
+---
+
+## 2. Identity and ownership model (read this before designing tools)
+
+- The connection's principal is the **`did`** from the verified JWT. Core binds
+  each running capture to the owning socket; only that socket can
+  `configure`/`stop` it. Any *other* authenticated connection may `subscribe`
+  read-only (device-open reads — see Appendix A policy A).
+- **The capture lives with its owning socket.** If the socket closes, the
+  capture stops and subscribers are detached. There is no detached/durable
+  capture that outlives its connection.
+- **Revocation** stops new connections and new captures immediately, but does
+  **not** tear down a socket that is already streaming (documented Prague
+  semantic; see Appendix A decision 3).
+
+Implication for MCP: a capture is only alive while MCP holds the WebSocket. Map
+this to explicit tool-invocation lifetime, not a background daemon that
+outlives a request — and never a protocol session id used as an auth cookie
+(the auth plan §2.2 forbids that). If MCP needs "start now, read later", MCP
+itself must hold the socket open and expose a handle; do not expect core to
+keep an ownerless capture.
+
+---
+
+## 3. How MCP should consume this (two viable shapes)
+
+### Shape A — MCP as the capture owner (recommended for summary tools)
+
+MCP opens the WebSocket, authenticates, `configure` + `start`, reads binary
+frames for a bounded window, dissects them, and returns a **summary** (AP list,
+frame counts, a specific frame decode). This fits the MCP tool model: a tool
+call does bounded work and returns structured data. `tools/capture_harness/`
+`run_owner` is exactly this flow.
+
+Good tools to expose:
+- `capture_scan(interface, channels, dwell_ms, duration_s)` → list of APs
+  (SSID, BSSID, channel, signal, security, PHY, tx power). The harness's
+  `parse_beacon` + `ScanTable` is a drop-in reference for the dissection.
+- `capture_frames(interface, channels, duration_s, pcap_filter)` → decoded
+  frame summaries or counts by type.
+- `list_capture_sources()` → wrap `get_supported_frequencies`.
+
+Do **not** stream raw pcap to the LLM; summarize. Return small JSON.
+
+### Shape B — MCP as a subscriber
+
+If another app (WebUI, a lab controller) owns a capture, MCP can `subscribe`
+with `data.session_id` from `list_sessions` and consume the same stream
+read-only. Use this for "observe the capture the instructor started". MCP still
+authenticates as itself; it does not need to be the owner.
+
+---
+
+## 4. Auth: where MCP's token comes from (do NOT hardcode)
+
+MCP forwards a wlanpi-core JWT as the WebSocket's first-message token. Per the
+auth plan:
+
+- The user's JWT is issued by core (`getjwt` for Prague; env/keychain on the
+  client, never pasted into `mcp.json`). MCP reads it the same way it reads the
+  token for its REST calls today.
+- After core issue #139 (credential-based dispatch, on branch
+  `feature/credential-auth-dispatch`), MCP presents a plain Bearer to core over
+  localhost with no `X-Wlanpi-Client` header. The capture WebSocket is on the
+  same core; use the same token.
+- Send the token **in the first WebSocket message only**. Never put it in the
+  URL query string — core refuses `?token=` (it would be logged) and closes
+  4401.
+
+The plan's longer-term "MCP validates its own audience, uses a service identity
+to core" direction (§2.2) applies to capture too, but for Prague the capture
+tools use the same user JWT flow as the rest of MCP.
+
+---
+
+## 5. Implementation checklist for the MCP capture module
+
+1. WebSocket client (the `websockets` library works; the harness uses it).
+2. Authenticate first; handle 4401 / `AUTH_FAILED` as a clean tool error.
+3. `configure` then `start`; capture the `session_id` from `CAPTURE_STARTED`.
+4. Incremental pcapng reader (chunks are unaligned; a new SHB can appear
+   mid-stream — reset interface state on it). See `PcapngReader` in the harness.
+5. Bounded read: stop after `duration_s` or a frame budget; always `stop` and
+   close in a `finally`.
+6. Dissect to a compact summary. Reuse the harness's radiotap + IE parsing
+   scope (SSID, channel, signal, security, HT/VHT/HE/EHT, tx power) or extend
+   it; do not ship raw pcap to the model.
+7. Surface `CHANNEL_SET_FAILED` reasons in the tool result — on single-radio
+   devices hopping can fail while the managed interface scans (see §7).
+8. Subscriber tool: `subscribe` with a `session_id` from `list_sessions`;
+   otherwise identical consumption.
+9. Never keep an ownerless background capture; tie capture lifetime to the tool
+   invocation (or to MCP explicitly holding the socket for a handle it owns).
+
+---
+
+## 6. TLS / transport
+
+Today the capture WebSocket is reachable on the plain core port `:31415`
+(loopback for on-box MCP). The P3 nginx TLS front-ends terminate HTTPS for the
+REST API and MCP but **do not yet forward the WebSocket `Upgrade`/`Connection`
+headers**, so `wss://` through nginx is not available until that is added
+(tracked as capture-TLS follow-up). On-box MCP calling core over loopback does
+not need TLS; a remote MCP consumer does, and that is gated on the nginx
+WebSocket-proxy change. Do not design around `wss://` through nginx yet.
+
+---
+
+## 7. Hardware reality: single-radio channel hopping
+
+On devices where the capture interface shares one phy with the managed `wlan0`
+(e.g. the Pi's onboard adapter), retuning the monitor interface fails with
+`Device or resource busy (-16)` while `wlan0` is scanning. Core retries a busy
+channel-set once; a persistent failure emits `CHANNEL_SET_FAILED` with the
+reason. For reliable multi-channel capture the device needs the managed
+interface down or a second adapter (its own phy). MCP tool docs should tell the
+user this rather than presenting a silent partial capture as complete.
+
+---
+
+## 8. Open questions to confirm with the core owner before shipping
+
+- Subscriber policy: Prague ships device-open reads (any valid token may
+  listen). If MCP needs per-stream ACLs, that is a core policy change
+  (Appendix A) — raise it, don't assume it.
+- Revocation vs live sockets: if a captured/leaked token must immediately kill
+  an in-flight MCP capture stream, that is a core change (Appendix A decision
+  3), currently "beyond Prague".
+- Durable/detached captures (start now, collect later without holding the
+  socket): not supported today; needs the REST session design, out of Prague
+  scope.

--- a/docs/capture-ws-mcp-handover.md
+++ b/docs/capture-ws-mcp-handover.md
@@ -157,9 +157,22 @@ Do **not** stream raw pcap to the LLM; summarize. Return small JSON.
 ### Shape B — MCP as a subscriber
 
 If another app (WebUI, a lab controller) owns a capture, MCP can `subscribe`
-with `data.session_id` from `list_sessions` and consume the same stream
-read-only. Use this for "observe the capture the instructor started". MCP still
-authenticates as itself; it does not need to be the owner.
+and consume the same stream read-only. MCP still authenticates as itself; it
+does not need to be the owner, and it does **not** need to know the owner's
+capture command or config. The only thing needed to attach is the
+`session_id`, which MCP discovers itself:
+
+- `list_sessions` returns every running capture with its `session_id`,
+  `interfaces`, `namespace`, and `config`. MCP picks the session on the
+  interface it cares about (one owner per interface, so the match is
+  unambiguous) and subscribes to that `session_id`.
+- The running `config` then arrives in the `SUBSCRIBED` event, so MCP learns
+  channels/width/dwell/filter after attaching — it is informed, but attaching
+  never depended on prior knowledge of the command.
+
+So a subscribe tool can take just an interface name (or nothing, defaulting to
+the only running capture) and resolve the session internally. The reference
+harness demonstrates this with `--subscribe-interface`.
 
 ---
 

--- a/docs/capture-ws-mcp-handover.md
+++ b/docs/capture-ws-mcp-handover.md
@@ -81,6 +81,15 @@ outlives a request — and never a protocol session id used as an auth cookie
 itself must hold the socket open and expose a handle; do not expect core to
 keep an ownerless capture.
 
+
+- **Namespaces:** core moves capture adapters into network namespaces (the
+  whole phy moves together). The WebSocket resolves the adapter's namespace
+  from core's own enumeration (`network_config.status()` / `iter_adapters`) and
+  runs the channel set, frequency query, and `dumpcap` inside that namespace.
+  MCP does not pass a namespace — it names the interface (`wlanpiN`), and core
+  finds where it lives. If the named interfaces are missing or split across
+  namespaces, `start` fails with `INTERFACE_NOT_AVAILABLE`.
+
 ---
 
 ## 2a. Deciding own vs subscribe, and reporting control
@@ -134,7 +143,13 @@ Good tools to expose:
   `parse_beacon` + `ScanTable` is a drop-in reference for the dissection.
 - `capture_frames(interface, channels, duration_s, pcap_filter)` → decoded
   frame summaries or counts by type.
-- `list_capture_sources()` → wrap `get_supported_frequencies`.
+- `list_capture_sources()` → wrap `get_supported_frequencies` (returns the
+  channel list per capture adapter, namespace-aware). For adapter/namespace/mode
+  discovery generally, use the existing REST endpoint
+  `GET /api/v1/network/config/status` (per-namespace adapter layout) rather than
+  waiting on a capture-specific sources API - that is a planned convenience
+  enhancement (adds a capture-capability filter and a `busy` flag), not a
+  prerequisite.
 
 Do **not** stream raw pcap to the LLM; summarize. Return small JSON.
 

--- a/docs/capture-ws-mcp-handover.md
+++ b/docs/capture-ws-mcp-handover.md
@@ -16,8 +16,8 @@ for core changes.
 A single WebSocket endpoint:
 
 ```
-ws://<host>:31415/api/v1/streaming/capture      (plain, current)
-wss://<host>:.../api/v1/streaming/capture       (TLS - see §6, not yet through nginx)
+ws://<host>:31415/api/v1/streaming/capture         (plain, through nginx)
+wss://<host>:31416/api/v1/streaming/capture        (TLS front-end, through nginx)
 ```
 
 It authenticates per-connection, runs one owned capture per socket, streams
@@ -221,13 +221,19 @@ tools use the same user JWT flow as the rest of MCP.
 
 ## 6. TLS / transport
 
-Today the capture WebSocket is reachable on the plain core port `:31415`
-(loopback for on-box MCP). The P3 nginx TLS front-ends terminate HTTPS for the
-REST API and MCP but **do not yet forward the WebSocket `Upgrade`/`Connection`
-headers**, so `wss://` through nginx is not available until that is added
-(tracked as capture-TLS follow-up). On-box MCP calling core over loopback does
-not need TLS; a remote MCP consumer does, and that is gated on the nginx
-WebSocket-proxy change. Do not design around `wss://` through nginx yet.
+The capture WebSocket is reachable two ways through nginx, both proxying the
+`Upgrade`/`Connection` headers with unbuffered, long-lived streaming:
+
+- **Plain** `ws://<host>:31415/api/v1/streaming/capture` — the default core
+  port; the right choice for **on-box MCP over loopback**, which needs no TLS.
+- **TLS** `wss://<host>:31416/api/v1/streaming/capture` — via the P3 TLS
+  front-end (feature-flagged, `wlanpi-core-tls enable api`); the right choice
+  for a **remote MCP consumer**. Clients must trust the device's self-signed
+  cert (connect by `wlanpi.local`, or distribute/TOFU the cert — the SAN does
+  not cover the LAN IP).
+
+So: on-box MCP uses loopback `ws://`; remote MCP uses `wss://` with cert trust.
+Both are live once the P6 and P3 branches are on the box.
 
 ---
 

--- a/docs/capture-ws-mcp-handover.md
+++ b/docs/capture-ws-mcp-handover.md
@@ -44,7 +44,7 @@ timeout / a token in the URL). After that:
 | `stop` | `{}` | owner only |
 | `subscribe` | `{"session_id": "cap_xxxx"}` | listen read-only to another socket's capture |
 | `unsubscribe` | `{}` | detach |
-| `list_sessions` | `{}` | enumerate running captures |
+| `list_sessions` | `{}` | enumerate running captures **with their running config** |
 
 Interface names must match `wlanpiN` (the monitor-mode interface), not `wlan0`.
 
@@ -82,6 +82,41 @@ itself must hold the socket open and expose a handle; do not expect core to
 keep an ownerless capture.
 
 ---
+
+## 2a. Deciding own vs subscribe, and reporting control
+
+Before capturing, MCP must decide whether to **own** a new capture or **join**
+an existing one, and it must tell its caller which it did.
+
+1. Send `list_sessions`. Each returned session carries `session_id`, `owner`
+   (the did), `interfaces`, and the full running `config` (per-interface
+   channels/width/dwell + `pcap_filter`).
+2. If a session already captures on the interface MCP wants:
+   - MCP **cannot** also own that interface — a `start` will fail with
+     `INTERFACE_IN_USE`. So MCP either subscribes to observe it, or reports the
+     conflict. Which one is a tool-design choice; make it explicit, don't retry
+     blindly.
+   - To observe: `subscribe` with that `session_id`. The `SUBSCRIBED` event
+     returns the same `config`, so MCP (and its caller) know exactly what is
+     being received — channels, width, dwell, filter — rather than guessing
+     from raw frames.
+3. If no session covers the interface: MCP owns it (`configure` + `start`) and
+   is in control.
+
+**Report the role back through the tool result.** Every capture tool response
+MUST state whether MCP is `owner` or `subscriber`, e.g.:
+
+```json
+{"role": "owner", "session_id": "cap_ab12", "config": { ... }, "aps": [ ... ]}
+{"role": "subscriber", "session_id": "cap_ab12", "owner": "webui-1",
+ "config": { ... }, "aps": [ ... ]}
+```
+
+The caller (the agent, or a harness driving MCP) then knows if MCP can
+stop/reconfigure the capture (owner) or is only listening (subscriber). The
+reference harness prints exactly this: an `OWNER` / `SUBSCRIBER` banner plus the
+config it learned. A subscriber is **never blind** — it always receives the
+owner's config in `SUBSCRIBED`.
 
 ## 3. How MCP should consume this (two viable shapes)
 

--- a/docs/capture-ws-mcp-handover.md
+++ b/docs/capture-ws-mcp-handover.md
@@ -98,7 +98,8 @@ Before capturing, MCP must decide whether to **own** a new capture or **join**
 an existing one, and it must tell its caller which it did.
 
 1. Send `list_sessions`. Each returned session carries `session_id`, `owner`
-   (the did), `interfaces`, and the full running `config` (per-interface
+   (the did), `interfaces`, `namespace` (which netns the capture runs in;
+   `null` for root), and the full running `config` (per-interface
    channels/width/dwell + `pcap_filter`).
 2. If a session already captures on the interface MCP wants:
    - MCP **cannot** also own that interface — a `start` will fail with

--- a/install/etc/wlanpi-core/nginx/wlanpi_core.conf
+++ b/install/etc/wlanpi-core/nginx/wlanpi_core.conf
@@ -14,6 +14,13 @@ map $http_x_wlanpi_client $wlanpi_real_ip {
     "mcp"     192.0.2.1;   # RFC 5737 TEST-NET-1 sentinel (non-loopback)
 }
 
+# WebSocket upgrade: map the client's Upgrade header to the right Connection
+# value so `location /api/v1/streaming/` can proxy the capture WebSocket.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ""      close;
+}
+
 log_format json_combined escape=json
     '{'
     '"timestamp":"$time_iso8601",'
@@ -34,6 +41,23 @@ server {
 
     access_log /var/log/wlanpi_core/nginx_access.log json_combined;
     error_log /var/log/wlanpi_core/nginx_error.log;
+
+    # Packet-capture WebSocket: needs HTTP/1.1 upgrade and long-lived,
+    # unbuffered streaming. X-Real-IP is the true client here (the WS
+    # authenticates via a first-message token, not the HMAC/JWT IP dispatch).
+    location /api/v1/streaming/ {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_buffering off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+        proxy_pass http://unix:/run/wlanpi_core.sock;
+    }
 
     location / {
         proxy_set_header Host $http_host;

--- a/tests/test_capture_ws_auth.py
+++ b/tests/test_capture_ws_auth.py
@@ -139,6 +139,7 @@ def _register_session(mgr, owner_ws, session_id, interfaces=("wlan0",)):
         },
         "pcap_filter": "type mgt",
     }
+    client["namespace"] = "wlan_ns"
     mgr.sessions[session_id] = owner_ws
     return client
 
@@ -166,6 +167,8 @@ async def test_subscriber_receives_broadcast_and_stop_notification():
     payload = next(e for e in subscribed if e["code"] == "SUBSCRIBED")
     assert payload["data"]["config"]["pcap_filter"] == "type mgt"
     assert "wlan0" in payload["data"]["config"]["interfaces"]
+    # The subscriber is told which namespace the capture runs in.
+    assert payload["data"]["namespace"] == "wlan_ns"
 
     await mgr._broadcast_chunk(owner, client, b"pcapng-bytes")
     owner.send_bytes.assert_awaited_once_with(b"pcapng-bytes")

--- a/tests/test_capture_ws_auth.py
+++ b/tests/test_capture_ws_auth.py
@@ -7,6 +7,7 @@ to read-only; only the owning socket controls it.
 """
 
 import asyncio
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -131,6 +132,13 @@ def _register_session(mgr, owner_ws, session_id, interfaces=("wlan0",)):
     client = mgr.clients[owner_ws]
     client["session_id"] = session_id
     client["interfaces"] = set(interfaces)
+    client["session_config"] = {
+        "interfaces": {
+            iface: {"channels": [{"freq": 2412, "width": 20}], "dwell_time": 250}
+            for iface in interfaces
+        },
+        "pcap_filter": "type mgt",
+    }
     mgr.sessions[session_id] = owner_ws
     return client
 
@@ -148,6 +156,16 @@ async def test_subscriber_receives_broadcast_and_stop_notification():
     await mgr.subscribe(listener, "cap_test")
     assert listener in client["subscribers"]
     assert mgr.clients[listener]["subscribed_to"] == "cap_test"
+
+    # The SUBSCRIBED event tells the listener the running config, so it is
+    # not blind to what it receives.
+    subscribed = [
+        json.loads(c.args[0])
+        for c in listener.send_text.await_args_list
+    ]
+    payload = next(e for e in subscribed if e["code"] == "SUBSCRIBED")
+    assert payload["data"]["config"]["pcap_filter"] == "type mgt"
+    assert "wlan0" in payload["data"]["config"]["interfaces"]
 
     await mgr._broadcast_chunk(owner, client, b"pcapng-bytes")
     owner.send_bytes.assert_awaited_once_with(b"pcapng-bytes")

--- a/tests/test_capture_ws_auth.py
+++ b/tests/test_capture_ws_auth.py
@@ -228,3 +228,97 @@ async def test_subscriber_disconnect_detaches_cleanly():
     await mgr.disconnect(listener)
     assert listener not in client["subscribers"]
     assert listener not in mgr.clients
+
+
+# --- Namespace awareness (#141 baseline: capture must run in the adapter's ns)
+
+
+def _status(**ns_ifaces):
+    """Build a network_config.status()-shaped dict: {ns_or_root: {iface: {...}}}."""
+    return {
+        ns: {iface: {"type": "monitor"} for iface in ifaces}
+        for ns, ifaces in ns_ifaces.items()
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_namespace_finds_named_namespace(mocker):
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    mgr = ConnectionManager.__new__(ConnectionManager)
+    mgr.__init__()
+    mocker.patch(
+        "wlanpi_core.streaming.connection_manager.network_config.status",
+        return_value=_status(root={}, wlan_ns=["wlanpi0"]),
+    )
+    ns, err = await mgr._resolve_namespace(["wlanpi0"])
+    assert err is None
+    assert ns == "wlan_ns"
+
+
+@pytest.mark.asyncio
+async def test_resolve_namespace_root_is_none(mocker):
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    mgr = ConnectionManager.__new__(ConnectionManager)
+    mgr.__init__()
+    mocker.patch(
+        "wlanpi_core.streaming.connection_manager.network_config.status",
+        return_value=_status(root=["wlanpi0"]),
+    )
+    ns, err = await mgr._resolve_namespace(["wlanpi0"])
+    assert err is None and ns is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_namespace_missing_interface_errors(mocker):
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    mgr = ConnectionManager.__new__(ConnectionManager)
+    mgr.__init__()
+    mocker.patch(
+        "wlanpi_core.streaming.connection_manager.network_config.status",
+        return_value=_status(root=["wlanpi9"]),
+    )
+    ns, err = await mgr._resolve_namespace(["wlanpi0"])
+    assert ns is None and "not found" in err
+
+
+@pytest.mark.asyncio
+async def test_resolve_namespace_split_across_namespaces_errors(mocker):
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    mgr = ConnectionManager.__new__(ConnectionManager)
+    mgr.__init__()
+    mocker.patch(
+        "wlanpi_core.streaming.connection_manager.network_config.status",
+        return_value=_status(ns_a=["wlanpi0"], ns_b=["wlanpi1"]),
+    )
+    ns, err = await mgr._resolve_namespace(["wlanpi0", "wlanpi1"])
+    assert ns is None and "multiple namespaces" in err
+
+
+def test_ns_prefix_wraps_named_namespace_only():
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    assert ConnectionManager._ns_prefix(None) == []
+    assert ConnectionManager._ns_prefix("wlan_ns") == [
+        "ip", "netns", "exec", "wlan_ns",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_set_channel_runs_in_namespace(mocker):
+    from wlanpi_core.models.command_result import CommandResult
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    mgr = ConnectionManager.__new__(ConnectionManager)
+    mgr.__init__()
+    run = mocker.patch(
+        "wlanpi_core.streaming.connection_manager.run_command_async",
+        return_value=CommandResult("", "", 0),
+    )
+    assert await mgr._set_channel("wlanpi0", 2412, 20, "wlan_ns") is None
+    cmd = run.call_args.args[0]
+    assert cmd[:4] == ["ip", "netns", "exec", "wlan_ns"]
+    assert "set" in cmd and "freq" in cmd

--- a/tests/test_capture_ws_auth.py
+++ b/tests/test_capture_ws_auth.py
@@ -325,3 +325,27 @@ async def test_set_channel_runs_in_namespace(mocker):
     cmd = run.call_args.args[0]
     assert cmd[:4] == ["ip", "netns", "exec", "wlan_ns"]
     assert "set" in cmd and "freq" in cmd
+
+
+@pytest.mark.asyncio
+async def test_subscriber_stop_does_not_end_owner_session():
+    """A subscriber is read-only: sending `stop` acts only on its own (empty)
+    client and must not stop or unregister the owner's capture."""
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    mgr = ConnectionManager.__new__(ConnectionManager)
+    mgr.__init__()
+    owner = await _connected(mgr, "owner-did")
+    listener = await _connected(mgr, "listener-did")
+    _register_session(mgr, owner, "cap_test")
+    await mgr.subscribe(listener, "cap_test")
+
+    await mgr.stop_streaming(listener)
+
+    # Owner's session survives untouched.
+    assert "cap_test" in mgr.sessions
+    assert mgr.sessions["cap_test"] is owner
+    assert mgr.clients[owner]["session_id"] == "cap_test"
+    # The subscriber was told its stop completed.
+    sent = [c.args[0] for c in listener.send_text.await_args_list]
+    assert any("CAPTURE_STOPPED" in payload for payload in sent)

--- a/tests/test_capture_ws_auth.py
+++ b/tests/test_capture_ws_auth.py
@@ -1,0 +1,212 @@
+"""Capture WebSocket authentication and subscriber model (#141, plan P6).
+
+The socket must authenticate with a first message carrying a core JWT;
+tokens in the URL are refused outright (query strings are logged by nginx).
+A running capture is a session other authenticated principals may subscribe
+to read-only; only the owning socket controls it.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+import wlanpi_core.api.api_v1.endpoints.streaming_api as streaming_api
+from wlanpi_core.api.api_v1.endpoints.streaming_api import WS_AUTH_CLOSE_CODE, manager
+from wlanpi_core.asgi import app
+
+WS_PATH = "/api/v1/streaming/capture"
+
+
+def _stub_token_manager(valid=True, did="tester"):
+    result = SimpleNamespace(
+        is_valid=valid,
+        device_id=did if valid else None,
+        payload={"did": did} if valid else None,
+        error=None if valid else "invalid",
+    )
+    return SimpleNamespace(verify_token=AsyncMock(return_value=result))
+
+
+def _assert_closed(websocket):
+    with pytest.raises(WebSocketDisconnect) as exc:
+        websocket.receive_json()
+    assert exc.value.code == WS_AUTH_CLOSE_CODE
+
+
+# --- Handshake --------------------------------------------------------------
+
+
+def test_token_in_url_is_refused():
+    with TestClient(app) as client:
+        with client.websocket_connect(f"{WS_PATH}?token=eyJhbGci") as websocket:
+            assert websocket.receive_json()["code"] == "AUTH_TOKEN_IN_URL"
+            _assert_closed(websocket)
+    assert manager.clients == {}
+
+
+def test_first_message_must_be_auth():
+    with TestClient(app) as client:
+        with client.websocket_connect(WS_PATH) as websocket:
+            websocket.send_json({"command": "get_supported_frequencies"})
+            assert websocket.receive_json()["code"] == "AUTH_REQUIRED"
+            _assert_closed(websocket)
+    assert manager.clients == {}
+
+
+def test_invalid_token_is_refused():
+    with TestClient(app) as client:
+        app.state.token_manager = _stub_token_manager(valid=False)
+        with client.websocket_connect(WS_PATH) as websocket:
+            websocket.send_json({"command": "auth", "token": "garbage"})
+            assert websocket.receive_json()["code"] == "AUTH_FAILED"
+            _assert_closed(websocket)
+
+
+def test_missing_token_field_is_refused():
+    with TestClient(app) as client:
+        with client.websocket_connect(WS_PATH) as websocket:
+            websocket.send_json({"command": "auth"})
+            assert websocket.receive_json()["code"] == "AUTH_FAILED"
+            _assert_closed(websocket)
+
+
+def test_auth_timeout_closes_socket(monkeypatch):
+    monkeypatch.setattr(streaming_api, "AUTH_TIMEOUT_SECONDS", 0.2)
+    with TestClient(app) as client:
+        with client.websocket_connect(WS_PATH) as websocket:
+            assert websocket.receive_json()["code"] == "AUTH_TIMEOUT"
+            _assert_closed(websocket)
+
+
+def test_valid_token_authenticates_and_protocol_continues():
+    with TestClient(app) as client:
+        app.state.token_manager = _stub_token_manager(did="student-1")
+        with client.websocket_connect(WS_PATH) as websocket:
+            websocket.send_json({"command": "auth", "token": "e.y.J"})
+            ok = websocket.receive_json()
+            assert ok["code"] == "AUTH_OK"
+            assert ok["data"]["did"] == "student-1"
+
+            websocket.send_json({"command": "auth", "token": "e.y.J"})
+            assert websocket.receive_json()["code"] == "ALREADY_AUTHENTICATED"
+
+            websocket.send_json({"command": "list_sessions"})
+            listing = websocket.receive_json()
+            assert listing["code"] == "SESSIONS"
+            assert listing["data"]["sessions"] == []
+
+            websocket.send_json({"command": "subscribe", "session_id": "cap_none"})
+            assert websocket.receive_json()["code"] == "SESSION_NOT_FOUND"
+    assert manager.clients == {}
+
+
+# --- Subscriber fan-out (manager unit level, mock sockets) ------------------
+
+
+class _MockWS:
+    """Hashable stand-in (manager keys clients by socket identity)."""
+
+    def __init__(self):
+        self.accept = AsyncMock()
+        self.send_bytes = AsyncMock()
+        self.send_text = AsyncMock()
+
+
+def _mock_ws():
+    return _MockWS()
+
+
+async def _connected(mgr, did):
+    ws = _mock_ws()
+    await mgr.connect(ws)
+    mgr.authenticate(ws, did)
+    return ws
+
+
+def _register_session(mgr, owner_ws, session_id, interfaces=("wlan0",)):
+    client = mgr.clients[owner_ws]
+    client["session_id"] = session_id
+    client["interfaces"] = set(interfaces)
+    mgr.sessions[session_id] = owner_ws
+    return client
+
+
+@pytest.mark.asyncio
+async def test_subscriber_receives_broadcast_and_stop_notification():
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    mgr = ConnectionManager.__new__(ConnectionManager)
+    mgr.__init__()
+    owner = await _connected(mgr, "owner-did")
+    listener = await _connected(mgr, "listener-did")
+    client = _register_session(mgr, owner, "cap_test")
+
+    await mgr.subscribe(listener, "cap_test")
+    assert listener in client["subscribers"]
+    assert mgr.clients[listener]["subscribed_to"] == "cap_test"
+
+    await mgr._broadcast_chunk(owner, client, b"pcapng-bytes")
+    owner.send_bytes.assert_awaited_once_with(b"pcapng-bytes")
+    listener.send_bytes.assert_awaited_once_with(b"pcapng-bytes")
+
+    await mgr._end_session(client, "CAPTURE_STOPPED", "Capture stopped.")
+    assert mgr.sessions == {}
+    assert client["subscribers"] == set()
+    assert mgr.clients[listener]["subscribed_to"] is None
+    # The stop notification reached the listener.
+    sent = [c.args[0] for c in listener.send_text.await_args_list]
+    assert any("CAPTURE_STOPPED" in payload for payload in sent)
+
+
+@pytest.mark.asyncio
+async def test_failing_subscriber_is_dropped_without_ending_capture():
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    mgr = ConnectionManager.__new__(ConnectionManager)
+    mgr.__init__()
+    owner = await _connected(mgr, "owner-did")
+    dead = await _connected(mgr, "dead-did")
+    client = _register_session(mgr, owner, "cap_test")
+
+    await mgr.subscribe(dead, "cap_test")
+    dead.send_bytes.side_effect = RuntimeError("gone")
+
+    await mgr._broadcast_chunk(owner, client, b"chunk")
+    assert dead not in client["subscribers"]
+    assert mgr.clients[dead]["subscribed_to"] is None
+    # Owner stream unaffected.
+    owner.send_bytes.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_owner_cannot_subscribe_to_own_session():
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    mgr = ConnectionManager.__new__(ConnectionManager)
+    mgr.__init__()
+    owner = await _connected(mgr, "owner-did")
+    _register_session(mgr, owner, "cap_test")
+
+    await mgr.subscribe(owner, "cap_test")
+    sent = [c.args[0] for c in owner.send_text.await_args_list]
+    assert any("SESSION_IS_OWN" in payload for payload in sent)
+
+
+@pytest.mark.asyncio
+async def test_subscriber_disconnect_detaches_cleanly():
+    from wlanpi_core.streaming.connection_manager import ConnectionManager
+
+    mgr = ConnectionManager.__new__(ConnectionManager)
+    mgr.__init__()
+    owner = await _connected(mgr, "owner-did")
+    listener = await _connected(mgr, "listener-did")
+    client = _register_session(mgr, owner, "cap_test")
+
+    await mgr.subscribe(listener, "cap_test")
+    await mgr.disconnect(listener)
+    assert listener not in client["subscribers"]
+    assert listener not in mgr.clients

--- a/tests/test_streaming_api.py
+++ b/tests/test_streaming_api.py
@@ -1,14 +1,28 @@
 """Behavioral tests for the packet-capture WebSocket protocol."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 from fastapi.testclient import TestClient
 
 from wlanpi_core.api.api_v1.endpoints.streaming_api import manager
 from wlanpi_core.asgi import app
 
 
+def _stub_token_manager():
+    result = SimpleNamespace(
+        is_valid=True, device_id="proto-test", payload={"did": "proto-test"}
+    )
+    return SimpleNamespace(verify_token=AsyncMock(return_value=result))
+
+
 def test_capture_websocket_reports_protocol_errors_and_disconnects_cleanly():
     with TestClient(app) as client:
+        app.state.token_manager = _stub_token_manager()
         with client.websocket_connect("/api/v1/streaming/capture") as websocket:
+            websocket.send_json({"command": "auth", "token": "e.y.J"})
+            assert websocket.receive_json()["code"] == "AUTH_OK"
+
             websocket.send_text("{")
             assert websocket.receive_json()["code"] == "INVALID_JSON"
 

--- a/tests/test_streaming_processes.py
+++ b/tests/test_streaming_processes.py
@@ -306,6 +306,34 @@ async def test_capture_rejects_invalid_start_before_process(mocker):
 
 
 @pytest.mark.asyncio
+async def test_set_channel_retries_once_when_phy_is_busy(mocker):
+    """A scan on a shared phy makes iw fail with EBUSY transiently; one
+    retry absorbs the common collision."""
+    manager = ConnectionManager()
+    busy = CommandResult("", "command failed: Device or resource busy (-16)", 240)
+    ok = CommandResult("", "", 0)
+    run = mocker.patch(
+        "wlanpi_core.streaming.connection_manager.run_command_async",
+        side_effect=[busy, ok],
+    )
+
+    assert await manager._set_channel("wlanpi0", 2412, 20) is None
+    assert run.call_count == 2
+
+
+async def test_set_channel_does_not_retry_non_busy_failures(mocker):
+    manager = ConnectionManager()
+    failed = CommandResult("", "command failed: Operation not supported (-95)", 240)
+    run = mocker.patch(
+        "wlanpi_core.streaming.connection_manager.run_command_async",
+        return_value=failed,
+    )
+
+    error = await manager._set_channel("wlanpi0", 2412, 20)
+    assert error is not None and "not supported" in error
+    assert run.call_count == 1
+
+
 async def test_set_channel_rejects_invalid_center_before_command(mocker):
     manager = ConnectionManager()
     run_command = mocker.patch.object(

--- a/tests/test_streaming_processes.py
+++ b/tests/test_streaming_processes.py
@@ -91,7 +91,7 @@ async def test_set_channel_uses_bounded_async_command(mocker):
         new=AsyncMock(return_value=CommandResult("", "", 0)),
     )
 
-    assert await manager._set_channel("wlanpi0", 5180, 20) is True
+    assert await manager._set_channel("wlanpi0", 5180, 20) is None
 
     run_command.assert_awaited_once_with(
         [connection_manager.IW_FILE, "dev", "wlanpi0", "set", "freq", "5180", "20"],
@@ -314,5 +314,5 @@ async def test_set_channel_rejects_invalid_center_before_command(mocker):
         new=AsyncMock(),
     )
 
-    assert await manager._set_channel("wlanpi0", 5000, 160) is False
+    assert await manager._set_channel("wlanpi0", 5000, 160) is not None
     run_command.assert_not_awaited()

--- a/tests/test_streaming_processes.py
+++ b/tests/test_streaming_processes.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -43,37 +43,53 @@ def _connected_client(manager, websocket):
         "task": None,
         "channel_tasks": {},
         "interfaces": set(),
+        "did": None,
+        "session_id": None,
+        "subscribers": set(),
+        "subscribed_to": None,
+        "namespace": None,
     }
+
+
+def _root_status(*ifaces):
+    """network_config.status()-shaped dict with adapters in root."""
+    return {"root": {iface: {"type": "monitor"} for iface in ifaces}}
+
+
+def _mock_root_adapters(mocker, *ifaces):
+    """Keep start_streaming / frequency discovery off the real iw path (AGENTS #6)."""
+    mocker.patch(
+        "wlanpi_core.streaming.connection_manager.network_config.status",
+        return_value=_root_status(*ifaces),
+    )
 
 
 @pytest.mark.asyncio
 async def test_supported_frequencies_uses_bounded_async_commands(mocker):
+    """Frequencies come from core adapter enumeration + per-phy iw channels,
+    never a root-only `iw dev` scrape (namespace-aware path)."""
     manager = ConnectionManager()
     websocket = object()
+    _mock_root_adapters(mocker, "wlanpi0")
+    mocker.patch(
+        "wlanpi_core.adapters.interface.get_interface_info",
+        return_value={"phy": "phy0"},
+    )
     run_command = mocker.patch.object(
         connection_manager,
         "run_command_async",
         new=AsyncMock(
-            side_effect=[
-                CommandResult("Interface wlanpi0\n", "", 0),
-                CommandResult("* 2412 MHz\n* 2437 MHz (disabled)\n", "", 0),
-            ]
+            return_value=CommandResult("* 2412 MHz\n* 2437 MHz (disabled)\n", "", 0),
         ),
     )
     send_event = mocker.patch.object(manager, "send_event", new=AsyncMock())
 
     await manager.send_supported_frequencies(websocket)
 
-    assert run_command.await_args_list == [
-        call(
-            [connection_manager.IW_FILE, "dev"],
-            timeout=connection_manager._IW_TIMEOUT_SEC,
-        ),
-        call(
-            [connection_manager.IW_FILE, "phy", "phy0", "channels"],
-            timeout=connection_manager._IW_TIMEOUT_SEC,
-        ),
-    ]
+    run_command.assert_awaited_once_with(
+        [connection_manager.IW_FILE, "phy", "phy0", "channels"],
+        timeout=connection_manager._IW_TIMEOUT_SEC,
+    )
     send_event.assert_awaited_once_with(
         websocket,
         "frequencies",
@@ -105,6 +121,7 @@ async def test_capture_process_is_isolated_and_reaped_on_stop(mocker):
     manager = ConnectionManager()
     websocket = object()
     _connected_client(manager, websocket)
+    _mock_root_adapters(mocker, "wlanpi0")
     process = CaptureProcess()
     create_process = mocker.patch.object(
         connection_manager.asyncio,
@@ -205,6 +222,7 @@ async def test_capture_interface_can_only_have_one_owner(mocker):
     second_websocket = object()
     _connected_client(manager, first_websocket)
     _connected_client(manager, second_websocket)
+    _mock_root_adapters(mocker, "wlanpi0")
     manager.configure(first_websocket, "wlanpi0", {})
     manager.configure(second_websocket, "wlanpi0", {})
     process = CaptureProcess()
@@ -240,6 +258,7 @@ async def test_shutdown_all_reaps_captures_and_discards_clients(mocker):
     manager = ConnectionManager()
     websocket = object()
     _connected_client(manager, websocket)
+    _mock_root_adapters(mocker, "wlanpi0")
     manager.configure(websocket, "wlanpi0", {})
     process = CaptureProcess()
     mocker.patch.object(
@@ -255,6 +274,7 @@ async def test_shutdown_all_reaps_captures_and_discards_clients(mocker):
     assert process.terminated is True
     assert manager.clients == {}
     assert manager.interface_owners == {}
+    assert manager.sessions == {}
 
 
 @pytest.mark.parametrize(

--- a/tools/capture_harness/README.md
+++ b/tools/capture_harness/README.md
@@ -1,0 +1,117 @@
+# Capture WebSocket test harness
+
+A standalone client for the wlanpi-core packet-capture WebSocket
+(`/api/v1/streaming/capture`). Use it to exercise the capture protocol,
+verify authentication and the owner/subscriber model, and eyeball a live AP
+scan without Wireshark. It is a **test/QA tool and a reference client**, not a
+production consumer.
+
+## Install
+
+```bash
+pip install websockets
+```
+
+Python 3.9+. The pcapng / radiotap / 802.11 dissection is built in — no scapy.
+
+## Get a token
+
+The WebSocket authenticates with a wlanpi-core JWT. On the device:
+
+```bash
+sudo getjwt harness -p 8000 --no-color
+```
+
+Copy the `access_token` value and either pass it with `--token` or export it:
+
+```bash
+export WLANPI_CAP_TOKEN='eyJ...'
+```
+
+## Connect target
+
+Point `--url` at the core server's HTTP port directly, e.g. the dev server:
+
+```bash
+sudo venv/bin/python -m wlanpi_core --debug --reload   # listens on :8000
+```
+
+Default `--url` is `ws://localhost:8000/api/v1/streaming/capture`. For another
+host use `ws://wlanpi.local:8000/api/v1/streaming/capture`.
+
+> nginx TLS front-ends do not forward the WebSocket upgrade yet, so `wss://`
+> through nginx (`:31416` / `:8443`) will not work until that lands. Connect to
+> the app/dev HTTP port for now.
+
+## Modes
+
+### 1. Build a config
+
+```bash
+./capture_harness.py config --interface wlanpi0 --channels 1,6,11,36,149 \
+    --width 20 --dwell 300 --out lab.json
+```
+
+`--channels` are channel numbers (2.4/5 GHz inferred); use `--freqs` for
+explicit MHz (needed for 6 GHz, e.g. `--freqs 5955,5975`). Output mirrors the
+WebSocket `configure` payload exactly, so it feeds straight into `run`.
+
+### 2. Run a capture (owner)
+
+```bash
+export WLANPI_CAP_TOKEN='eyJ...'
+./capture_harness.py run --config lab.json --duration 30 --raw-out scan.pcapng
+```
+
+Authenticates, configures, starts the capture, prints the **session id**, then
+shows a rolling AP scan every few seconds. `--raw-out` also saves the raw
+pcapng for opening in Wireshark. Ctrl-C stops cleanly.
+
+### 3. Subscribe (read-only, second instance)
+
+The owner prints a ready-to-paste subscribe command. From another terminal
+(optionally a different token, to prove cross-principal read access):
+
+```bash
+./capture_harness.py run --subscribe cap_ab12cd34 --duration 30
+```
+
+The subscriber receives the identical binary stream but cannot control the
+capture. It stops receiving when the owner stops or disconnects.
+
+### 4. List sessions
+
+```bash
+./capture_harness.py list
+```
+
+## Example scan output
+
+```
+BSSID              CH  SIG SEC       PHY          TXP CC      #  SSID
+------------------------------------------------------------------------------
+00:11:22:33:44:55   6  -42 WPA2-PSK  g/n/ac/ax     20 GB      1  TestNet
+
+1 AP(s), 0 non-beacon frame(s)
+```
+
+Columns: BSSID, channel, last signal (dBm), security (Open/WEP/WPA/WPA2-PSK/
+WPA2-Ent/WPA3/WPA2/3), PHY amendments present (g/a + n/ac/ax/be), TX power
+(dBm, from radiotap or a TPC report IE), country code, beacon count, SSID.
+
+## Single-radio devices
+
+On a Pi whose capture interface shares one radio (phy) with the managed
+`wlan0`, channel hopping can stutter or fail while `wlan0` scans. For
+glitch-free hopping either take the managed interface down
+(`sudo ip link set wlan0 down` — not over a Wi-Fi SSH session) or use an
+external adapter with its own phy. Core retries a transiently-busy channel set
+once; a persistent failure appears as a `CHANNEL_SET_FAILED` event carrying the
+`iw` reason.
+
+## Dissector scope
+
+Deliberately minimal: radiotap first-present-word fields (channel, signal, TX
+power) and the IEs SSID, DS channel, country, RSN/WPA, HT/VHT/HE/EHT presence,
+and TPC-report TX power. For full analysis, open the `--raw-out` pcapng in
+Wireshark.

--- a/tools/capture_harness/README.md
+++ b/tools/capture_harness/README.md
@@ -76,14 +76,24 @@ The owner prints a ready-to-paste subscribe command. From another terminal
 ./capture_harness.py run --subscribe cap_ab12cd34 --duration 30
 ```
 
-The subscriber receives the identical binary stream but cannot control the
-capture. It stops receiving when the owner stops or disconnects.
+The subscriber prints a `SUBSCRIBER` banner and the owner's running config
+(channels, width, dwell, filter) learned from the `SUBSCRIBED` event — it is
+never blind to what it receives — then the identical binary stream. It cannot
+control the capture and stops receiving when the owner stops or disconnects.
+
+The owner prints an `OWNER` banner. If the interface you ask to capture is
+already owned by another session, the owner run warns you (with the
+`--subscribe` command to observe it instead) before `start` fails with
+`INTERFACE_IN_USE`.
 
 ### 4. List sessions
 
 ```bash
 ./capture_harness.py list
 ```
+
+Each session is printed with its running config (channels, dwell, filter), so
+you can see what an existing capture is doing before deciding to subscribe.
 
 ## Example scan output
 

--- a/tools/capture_harness/README.md
+++ b/tools/capture_harness/README.md
@@ -69,8 +69,19 @@ pcapng for opening in Wireshark. Ctrl-C stops cleanly.
 
 ### 3. Subscribe (read-only, second instance)
 
-The owner prints a ready-to-paste subscribe command. From another terminal
+You do **not** need the owner's capture command or config to attach — only a
+session id, and you can discover that yourself. Two ways from another terminal
 (optionally a different token, to prove cross-principal read access):
+
+Discover by interface (no session id needed — the harness runs `list_sessions`
+and picks the capture on that interface; there is only one owner per interface):
+
+```bash
+./capture_harness.py run --subscribe-interface wlanpi0 --duration 30
+```
+
+Or, if you already have the id (the owner prints a ready-to-paste command as a
+convenience):
 
 ```bash
 ./capture_harness.py run --subscribe cap_ab12cd34 --duration 30

--- a/tools/capture_harness/capture_harness.py
+++ b/tools/capture_harness/capture_harness.py
@@ -549,8 +549,31 @@ async def run_subscriber(args) -> None:
     async with websockets.connect(args.url, max_size=None) as ws:
         did = await _authenticate(ws, token)
         print(f"[auth] authenticated as did={did}", file=sys.stderr)
+
+        # A real-world subscriber rarely has the owner's session id handed to
+        # it. Discover it: list running captures and pick the one on the
+        # requested interface (only one owner per interface, so unambiguous).
+        session_id = args.subscribe
+        if not session_id:
+            sessions = await _find_sessions(ws)
+            matches = [
+                s
+                for s in sessions
+                if args.subscribe_interface in s.get("interfaces", [])
+            ]
+            if not matches:
+                raise RuntimeError(
+                    f"no running capture on {args.subscribe_interface}; "
+                    "run `list` to see what is available"
+                )
+            session_id = matches[0]["session_id"]
+            print(
+                f"[discover] {args.subscribe_interface} -> session {session_id}",
+                file=sys.stderr,
+            )
+
         await ws.send(
-            json.dumps({"command": "subscribe", "session_id": args.subscribe})
+            json.dumps({"command": "subscribe", "session_id": session_id})
         )
         # Learn the running config before consuming, so we are not blind.
         while True:
@@ -563,7 +586,7 @@ async def run_subscriber(args) -> None:
                 print("=" * 60)
                 print(f"  ROLE: SUBSCRIBER (read-only, not in control)")
                 ns = data.get("namespace") or "root"
-                print(f"  session {args.subscribe} owned by "
+                print(f"  session {session_id} owned by "
                       f"did={data.get('owner')} in namespace {ns}")
                 _print_config(data.get("config"))
                 print("=" * 60)
@@ -673,6 +696,11 @@ def main() -> None:
     g = pr.add_mutually_exclusive_group(required=True)
     g.add_argument("--config", help="config JSON to start a capture (owner)")
     g.add_argument("--subscribe", help="session id to listen to (read-only)")
+    g.add_argument(
+        "--subscribe-interface",
+        help="listen to whatever capture is running on this interface "
+        "(discovered via list_sessions; no session id needed)",
+    )
 
     pl = sub.add_parser("list", help="list running capture sessions")
     add_client_args(pl)

--- a/tools/capture_harness/capture_harness.py
+++ b/tools/capture_harness/capture_harness.py
@@ -25,10 +25,11 @@ Auth: the token is a wlanpi-core JWT. Get one on the device with
 Pass it with --token or the WLANPI_CAP_TOKEN environment variable. Tokens are
 NEVER placed in the URL (the server refuses that; query strings get logged).
 
-Transport note: connect straight to the dev/app server port (e.g.
-ws://wlanpi.local:8000/api/v1/streaming/capture). nginx TLS front-ends do not
-yet forward the WebSocket upgrade, so wss:// through nginx will not work until
-that lands.
+Transport note: the capture WebSocket works through nginx - plain
+ws://<host>:31415/api/v1/streaming/capture, or wss://<host>:31416/... via the
+P3 TLS front-end (trust the device cert; connect by wlanpi.local). For local
+development you can also hit the dev/app server port directly, e.g.
+ws://wlanpi.local:8000/api/v1/streaming/capture.
 
 Dissector limitations (documented on purpose; this is a test tool, not
 Wireshark): radiotap parsing reads the first present-word only (covers channel,

--- a/tools/capture_harness/capture_harness.py
+++ b/tools/capture_harness/capture_harness.py
@@ -557,8 +557,9 @@ async def run_subscriber(args) -> None:
                 data = event.get("data", {})
                 print("=" * 60)
                 print(f"  ROLE: SUBSCRIBER (read-only, not in control)")
+                ns = data.get("namespace") or "root"
                 print(f"  session {args.subscribe} owned by "
-                      f"did={data.get('owner')}")
+                      f"did={data.get('owner')} in namespace {ns}")
                 _print_config(data.get("config"))
                 print("=" * 60)
                 break
@@ -594,6 +595,7 @@ async def run_list(args) -> None:
                 for sess in sessions:
                     print(
                         f"{sess['session_id']}  owner={sess.get('owner')}  "
+                        f"ns={sess.get('namespace') or 'root'}  "
                         f"interfaces={','.join(sess.get('interfaces', []))}"
                     )
                     _print_config(sess.get("config"))

--- a/tools/capture_harness/capture_harness.py
+++ b/tools/capture_harness/capture_harness.py
@@ -436,6 +436,11 @@ async def _consume(ws, table: ScanTable, refresh: float, deadline: Optional[floa
             if code not in ("CHANNEL_SET",):  # keep hop spam down
                 note = data.get("message") or data
                 print(f"[event] {code}: {note}", file=sys.stderr)
+            if code in ("CAPTURE_ENDED", "CAPTURE_STOPPED"):
+                # The capture is over (owner stopped, or dumpcap exited);
+                # stop consuming instead of idling on a dead session.
+                print("[capture ended] stopping.", file=sys.stderr)
+                return
         now = time.monotonic()
         if now - last_print >= refresh:
             print("\n" + table.render())

--- a/tools/capture_harness/capture_harness.py
+++ b/tools/capture_harness/capture_harness.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""
+wlanpi-core capture WebSocket test harness.
+
+Two modes:
+
+  config   Build a reusable capture config (adapter, channels, dwell, filter)
+           and write it to JSON. No device contact.
+
+  run      Connect to the capture WebSocket, authenticate, then EITHER start a
+           capture from a config file (owner) OR subscribe read-only to an
+           existing session. Dissects the live pcapng stream and prints a
+           rolling AP scan (SSID, BSSID, channel, signal, security, PHY
+           amendments, TX power).
+
+  list     Authenticate and print the running capture sessions.
+
+Run several instances at once: one `run --config ...` owns a capture and prints
+its session id; another `run --subscribe <session_id>` listens in read-only.
+
+Dependencies: websockets (`pip install websockets`). The dissector is built in.
+
+Auth: the token is a wlanpi-core JWT. Get one on the device with
+`sudo getjwt <name> -p <port> --no-color` and read the "access_token" field.
+Pass it with --token or the WLANPI_CAP_TOKEN environment variable. Tokens are
+NEVER placed in the URL (the server refuses that; query strings get logged).
+
+Transport note: connect straight to the dev/app server port (e.g.
+ws://wlanpi.local:8000/api/v1/streaming/capture). nginx TLS front-ends do not
+yet forward the WebSocket upgrade, so wss:// through nginx will not work until
+that lands.
+
+Dissector limitations (documented on purpose; this is a test tool, not
+Wireshark): radiotap parsing reads the first present-word only (covers channel,
+signal, TX power); IE parsing covers SSID, DS channel, country, RSN/WPA, HT/VHT/
+HE/EHT presence, and TPC report TX power.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import struct
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+try:
+    import websockets
+except ImportError:
+    sys.exit("This harness needs the 'websockets' package: pip install websockets")
+
+DEFAULT_URL = "ws://localhost:8000/api/v1/streaming/capture"
+AUTH_TIMEOUT = 10.0
+
+# ---------------------------------------------------------------------------
+# Channel / frequency helpers
+# ---------------------------------------------------------------------------
+
+
+def channel_to_freq(ch: int) -> int:
+    if ch == 14:
+        return 2484
+    if 1 <= ch <= 13:
+        return 2412 + (ch - 1) * 5
+    if 32 <= ch <= 196:  # 5 GHz
+        return 5000 + ch * 5
+    raise ValueError(f"cannot map channel {ch} to a frequency; use --freqs for 6 GHz")
+
+
+def freq_to_channel(freq: int) -> Optional[int]:
+    if freq == 2484:
+        return 14
+    if 2412 <= freq <= 2472:
+        return (freq - 2412) // 5 + 1
+    if 5000 <= freq <= 5895:
+        return (freq - 5000) // 5
+    if 5955 <= freq <= 7115:  # 6 GHz
+        return (freq - 5950) // 5
+    return None
+
+
+# ---------------------------------------------------------------------------
+# pcapng stream reader (incremental; chunks arrive unaligned)
+# ---------------------------------------------------------------------------
+
+
+class PcapngReader:
+    """Feed arbitrary byte chunks; yields (linktype, packet_bytes) per packet."""
+
+    SHB = 0x0A0D0D0A
+    IDB = 0x00000001
+    EPB = 0x00000006
+
+    def __init__(self) -> None:
+        self.buf = bytearray()
+        self.endian = "<"
+        self.linktypes: Dict[int, int] = {}
+        self._iface_seq = 0
+
+    def feed(self, data: bytes) -> List[Tuple[int, bytes]]:
+        self.buf += data
+        out: List[Tuple[int, bytes]] = []
+        while len(self.buf) >= 12:
+            if bytes(self.buf[0:4]) == b"\x0a\x0d\x0d\x0a":
+                bom = bytes(self.buf[8:12])
+                if bom == b"\x4d\x3c\x2b\x1a":
+                    self.endian = "<"
+                elif bom == b"\x1a\x2b\x3c\x4d":
+                    self.endian = ">"
+            total_len = struct.unpack(self.endian + "I", self.buf[4:8])[0]
+            if total_len < 12 or total_len % 4 != 0:
+                # Desynced; drop a byte and try to re-find a block boundary.
+                self.buf.pop(0)
+                continue
+            if len(self.buf) < total_len:
+                break
+            block = bytes(self.buf[:total_len])
+            del self.buf[:total_len]
+            self._handle_block(block, out)
+        return out
+
+    def _handle_block(self, block: bytes, out: List[Tuple[int, bytes]]) -> None:
+        e = self.endian
+        btype = struct.unpack_from(e + "I", block, 0)[0]
+        if btype == self.SHB:
+            # New section: interface numbering restarts.
+            self.linktypes = {}
+            self._iface_seq = 0
+        elif btype == self.IDB:
+            linktype = struct.unpack_from(e + "H", block, 8)[0]
+            self.linktypes[self._iface_seq] = linktype
+            self._iface_seq += 1
+        elif btype == self.EPB:
+            if len(block) < 28:
+                return
+            iface_id = struct.unpack_from(e + "I", block, 8)[0]
+            caplen = struct.unpack_from(e + "I", block, 20)[0]
+            pkt = block[28 : 28 + caplen]
+            out.append((self.linktypes.get(iface_id, 127), pkt))
+
+
+# ---------------------------------------------------------------------------
+# Radiotap + 802.11 dissection
+# ---------------------------------------------------------------------------
+
+# (align, size) for radiotap present bits 0..14 - enough for our targets.
+_RT_FIELDS = {
+    0: (8, 8), 1: (1, 1), 2: (1, 1), 3: (2, 4), 4: (2, 2), 5: (1, 1),
+    6: (1, 1), 7: (2, 2), 8: (2, 2), 9: (2, 2), 10: (1, 1), 11: (1, 1),
+    12: (1, 1), 13: (1, 1), 14: (2, 2),
+}
+
+
+def parse_radiotap(buf: bytes) -> Tuple[dict, int]:
+    """Return ({freq, signal, txpower}, header_len). header_len 0 on failure."""
+    info = {"freq": None, "signal": None, "txpower": None}
+    if len(buf) < 8:
+        return info, 0
+    _ver, _pad, length = struct.unpack_from("<BBH", buf, 0)
+    if length < 8 or length > len(buf):
+        return info, 0
+    present_words = []
+    off = 4
+    while off + 4 <= len(buf):
+        word = struct.unpack_from("<I", buf, off)[0]
+        present_words.append(word)
+        off += 4
+        if not (word & (1 << 31)):
+            break
+    if not present_words:
+        return info, length
+    pos = off
+    present = present_words[0]
+    for bit in range(0, 15):
+        if not (present & (1 << bit)):
+            continue
+        align, size = _RT_FIELDS[bit]
+        if pos % align:
+            pos += align - (pos % align)
+        if pos + size > length:
+            break
+        if bit == 3:
+            info["freq"] = struct.unpack_from("<H", buf, pos)[0]
+        elif bit == 5:
+            info["signal"] = struct.unpack_from("<b", buf, pos)[0]
+        elif bit == 10:
+            info["txpower"] = struct.unpack_from("<b", buf, pos)[0]
+        pos += size
+    return info, length
+
+
+_OUI_RSN = b"\x00\x0f\xac"
+_OUI_MS = b"\x00\x50\xf2"
+
+
+def _rsn_security(val: bytes) -> str:
+    try:
+        off = 2 + 4  # version + group cipher
+        pw_count = int.from_bytes(val[off : off + 2], "little")
+        off += 2 + 4 * pw_count
+        akm_count = int.from_bytes(val[off : off + 2], "little")
+        off += 2
+        akm_types = set()
+        for _ in range(akm_count):
+            suite = val[off : off + 4]
+            off += 4
+            if suite[:3] == _OUI_RSN:
+                akm_types.add(suite[3])
+        has_sae = bool(akm_types & {8, 9})
+        has_psk = bool(akm_types & {2, 4, 6})
+        has_ent = bool(akm_types & {1, 3, 5})
+        if has_sae and has_psk:
+            return "WPA2/3"
+        if has_sae:
+            return "WPA3"
+        if has_ent:
+            return "WPA2-Ent"
+        if has_psk:
+            return "WPA2-PSK"
+        return "WPA2"
+    except Exception:
+        return "WPA2"
+
+
+@dataclass
+class ApInfo:
+    bssid: str = ""
+    ssid: str = ""
+    channel: Optional[int] = None
+    signal: Optional[int] = None
+    security: str = "Open"
+    phy: set = field(default_factory=set)
+    txpower: Optional[int] = None
+    country: str = ""
+    count: int = 0
+    last_seen: float = 0.0
+
+
+def parse_beacon(pkt: bytes, radio: dict) -> Optional[ApInfo]:
+    """Parse a management beacon/probe-response into ApInfo, else None."""
+    rt_info, rtlen = parse_radiotap(pkt)
+    if rtlen == 0:
+        return None
+    if len(pkt) < rtlen + 24:
+        return None
+    fc = struct.unpack_from("<H", pkt, rtlen)[0]
+    ftype = (fc >> 2) & 0x3
+    subtype = (fc >> 4) & 0xF
+    if ftype != 0 or subtype not in (5, 8):  # mgmt beacon(8)/probe-resp(5)
+        return None
+
+    ap = ApInfo()
+    ap.bssid = ":".join(f"{b:02x}" for b in pkt[rtlen + 16 : rtlen + 22])
+    ap.signal = rt_info.get("signal")
+    ap.txpower = rt_info.get("txpower")
+    if rt_info.get("freq"):
+        ap.channel = freq_to_channel(rt_info["freq"])
+
+    # capability info (privacy bit) then tagged IEs
+    caps_off = rtlen + 24 + 8 + 2  # + timestamp(8) + interval(2)
+    privacy = False
+    if caps_off + 2 <= len(pkt):
+        caps = struct.unpack_from("<H", pkt, caps_off)[0]
+        privacy = bool(caps & 0x0010)
+
+    p = rtlen + 24 + 12
+    end = len(pkt)
+    have_rsn = have_wpa = False
+    while p + 2 <= end:
+        tag = pkt[p]
+        ln = pkt[p + 1]
+        val = pkt[p + 2 : p + 2 + ln]
+        p += 2 + ln
+        if len(val) < ln:
+            break
+        if tag == 0:
+            ap.ssid = val.decode("utf-8", "replace") if val else "<hidden>"
+        elif tag == 3 and val:
+            ap.channel = val[0]
+        elif tag == 7 and len(val) >= 2:
+            ap.country = val[:2].decode("ascii", "replace")
+        elif tag == 35 and val:  # TPC report: tx power, link margin
+            ap.txpower = struct.unpack_from("<b", val, 0)[0]
+        elif tag == 45:
+            ap.phy.add("n")
+        elif tag == 48:
+            have_rsn = True
+            ap.security = _rsn_security(val)
+        elif tag == 191:
+            ap.phy.add("ac")
+        elif tag == 221 and val[:3] == _OUI_MS and len(val) >= 4 and val[3] == 1:
+            have_wpa = True
+        elif tag == 255 and val:  # extension IEs
+            ext = val[0]
+            if ext in (35, 36):
+                ap.phy.add("ax")
+            elif ext in (106, 108):
+                ap.phy.add("be")
+
+    if not have_rsn:
+        if have_wpa:
+            ap.security = "WPA"
+        elif privacy:
+            ap.security = "WEP"
+        else:
+            ap.security = "Open"
+    return ap
+
+
+_PHY_ORDER = ["n", "ac", "ax", "be"]
+
+
+def phy_label(ap: ApInfo) -> str:
+    base = "g" if (ap.channel or 0) <= 14 else "a"
+    amend = [x for x in _PHY_ORDER if x in ap.phy]
+    return "/".join([base] + amend)
+
+
+# ---------------------------------------------------------------------------
+# Scan table
+# ---------------------------------------------------------------------------
+
+
+class ScanTable:
+    def __init__(self) -> None:
+        self.aps: Dict[str, ApInfo] = {}
+        self.other = 0
+
+    def update(self, ap: ApInfo) -> None:
+        existing = self.aps.get(ap.bssid)
+        if existing is None:
+            ap.count = 1
+            ap.last_seen = time.monotonic()
+            self.aps[ap.bssid] = ap
+            return
+        existing.count += 1
+        existing.last_seen = time.monotonic()
+        if ap.ssid and ap.ssid != "<hidden>":
+            existing.ssid = ap.ssid
+        if ap.channel:
+            existing.channel = ap.channel
+        if ap.signal is not None:
+            existing.signal = ap.signal
+        if ap.txpower is not None:
+            existing.txpower = ap.txpower
+        if ap.country:
+            existing.country = ap.country
+        if ap.security != "Open":
+            existing.security = ap.security
+        existing.phy |= ap.phy
+
+    def render(self) -> str:
+        rows = sorted(
+            self.aps.values(),
+            key=lambda a: (a.channel or 999, -(a.signal or -999)),
+        )
+        lines = [
+            f"{'BSSID':<17} {'CH':>3} {'SIG':>4} {'SEC':<9} "
+            f"{'PHY':<11} {'TXP':>4} {'CC':<3} {'#':>5}  SSID"
+        ]
+        lines.append("-" * 78)
+        for a in rows:
+            lines.append(
+                f"{a.bssid:<17} {str(a.channel or '?'):>3} "
+                f"{str(a.signal if a.signal is not None else '?'):>4} "
+                f"{a.security:<9} {phy_label(a):<11} "
+                f"{str(a.txpower if a.txpower is not None else '?'):>4} "
+                f"{a.country:<3} {a.count:>5}  {a.ssid[:32]}"
+            )
+        lines.append(
+            f"\n{len(self.aps)} AP(s), {self.other} non-beacon frame(s)"
+        )
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket client
+# ---------------------------------------------------------------------------
+
+
+def resolve_token(args) -> str:
+    if args.token:
+        return args.token
+    env = os.environ.get(args.token_env)
+    if env:
+        return env
+    sys.exit(
+        f"No token. Pass --token or set ${args.token_env}. "
+        "Get one with: sudo getjwt <name> -p <port> --no-color"
+    )
+
+
+async def _authenticate(ws, token: str) -> str:
+    await ws.send(json.dumps({"command": "auth", "token": token}))
+    while True:
+        msg = await asyncio.wait_for(ws.recv(), timeout=AUTH_TIMEOUT)
+        if isinstance(msg, bytes):
+            continue
+        event = json.loads(msg)
+        code = event.get("code")
+        if code == "AUTH_OK":
+            return event.get("data", {}).get("did", "?")
+        raise RuntimeError(f"auth failed: {code} {event.get('data')}")
+
+
+async def _consume(ws, table: ScanTable, refresh: float, deadline: Optional[float],
+                   raw_fp) -> None:
+    reader = PcapngReader()
+    last_print = 0.0
+    while True:
+        if deadline and time.monotonic() >= deadline:
+            return
+        timeout = refresh
+        if deadline:
+            timeout = min(refresh, max(0.05, deadline - time.monotonic()))
+        try:
+            msg = await asyncio.wait_for(ws.recv(), timeout=timeout)
+        except asyncio.TimeoutError:
+            msg = None
+        if isinstance(msg, bytes):
+            if raw_fp:
+                raw_fp.write(msg)
+            for linktype, pkt in reader.feed(msg):
+                radio = {}
+                ap = parse_beacon(pkt, radio)
+                if ap:
+                    table.update(ap)
+                else:
+                    table.other += 1
+        elif isinstance(msg, str):
+            event = json.loads(msg)
+            code = event.get("code", "")
+            data = event.get("data", {})
+            if code not in ("CHANNEL_SET",):  # keep hop spam down
+                note = data.get("message") or data
+                print(f"[event] {code}: {note}", file=sys.stderr)
+        now = time.monotonic()
+        if now - last_print >= refresh:
+            print("\n" + table.render())
+            last_print = now
+
+
+async def run_owner(args) -> None:
+    token = resolve_token(args)
+    with open(args.config) as fh:
+        config = json.load(fh)
+    interfaces = config["interfaces"]
+    pcap_filter = config.get("pcap_filter", "")
+
+    async with websockets.connect(args.url, max_size=None) as ws:
+        did = await _authenticate(ws, token)
+        print(f"[auth] authenticated as did={did}", file=sys.stderr)
+
+        await ws.send(json.dumps({"command": "configure", "interfaces": interfaces}))
+        await ws.send(
+            json.dumps(
+                {
+                    "command": "start",
+                    "interfaces": list(interfaces.keys()),
+                    "pcap_filter": pcap_filter,
+                }
+            )
+        )
+        # Wait for CAPTURE_STARTED to surface the session id.
+        session_id = None
+        while session_id is None:
+            msg = await asyncio.wait_for(ws.recv(), timeout=AUTH_TIMEOUT)
+            if isinstance(msg, bytes):
+                continue
+            event = json.loads(msg)
+            if event.get("code") == "CAPTURE_STARTED":
+                session_id = event.get("data", {}).get("session_id")
+            elif event.get("event") == "error":
+                raise RuntimeError(f"start failed: {event.get('data')}")
+        print("=" * 60)
+        print(f"  CAPTURE SESSION: {session_id}")
+        print(f"  subscribe from another instance:")
+        print(f"    capture_harness.py run --subscribe {session_id} "
+              f"--url {args.url}")
+        print("=" * 60)
+
+        raw_fp = open(args.raw_out, "wb") if args.raw_out else None
+        table = ScanTable()
+        deadline = time.monotonic() + args.duration if args.duration else None
+        try:
+            await _consume(ws, table, args.refresh, deadline, raw_fp)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            try:
+                await ws.send(json.dumps({"command": "stop"}))
+            except Exception:
+                pass
+            if raw_fp:
+                raw_fp.close()
+                print(f"\n[raw] wrote pcapng to {args.raw_out}", file=sys.stderr)
+        print("\nFINAL SCAN:\n" + table.render())
+
+
+async def run_subscriber(args) -> None:
+    token = resolve_token(args)
+    async with websockets.connect(args.url, max_size=None) as ws:
+        did = await _authenticate(ws, token)
+        print(f"[auth] authenticated as did={did}", file=sys.stderr)
+        await ws.send(
+            json.dumps({"command": "subscribe", "session_id": args.subscribe})
+        )
+        raw_fp = open(args.raw_out, "wb") if args.raw_out else None
+        table = ScanTable()
+        deadline = time.monotonic() + args.duration if args.duration else None
+        try:
+            await _consume(ws, table, args.refresh, deadline, raw_fp)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            if raw_fp:
+                raw_fp.close()
+        print("\nFINAL SCAN (subscriber):\n" + table.render())
+
+
+async def run_list(args) -> None:
+    token = resolve_token(args)
+    async with websockets.connect(args.url, max_size=None) as ws:
+        await _authenticate(ws, token)
+        await ws.send(json.dumps({"command": "list_sessions"}))
+        while True:
+            msg = await asyncio.wait_for(ws.recv(), timeout=AUTH_TIMEOUT)
+            if isinstance(msg, bytes):
+                continue
+            event = json.loads(msg)
+            if event.get("code") == "SESSIONS":
+                sessions = event.get("data", {}).get("sessions", [])
+                if not sessions:
+                    print("no running capture sessions")
+                for s in sessions:
+                    print(
+                        f"{s['session_id']}  owner={s.get('owner')}  "
+                        f"interfaces={','.join(s.get('interfaces', []))}"
+                    )
+                return
+
+
+# ---------------------------------------------------------------------------
+# config builder
+# ---------------------------------------------------------------------------
+
+
+def build_config(args) -> None:
+    channels = []
+    if args.freqs:
+        for f in args.freqs.split(","):
+            channels.append({"freq": int(f), "width": args.width})
+    if args.channels:
+        for c in args.channels.split(","):
+            channels.append({"freq": channel_to_freq(int(c)), "width": args.width})
+    if not channels:
+        sys.exit("provide --channels and/or --freqs")
+    config = {
+        "interfaces": {
+            args.interface: {
+                "channels": channels,
+                "dwell_time": args.dwell,
+            }
+        },
+        "pcap_filter": args.filter or "",
+    }
+    text = json.dumps(config, indent=2)
+    if args.out:
+        with open(args.out, "w") as fh:
+            fh.write(text + "\n")
+        print(f"wrote {args.out}")
+        print(f"  {len(channels)} channel(s) on {args.interface}, "
+              f"dwell {args.dwell}ms")
+    else:
+        print(text)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    pc = sub.add_parser("config", help="build a capture config JSON")
+    pc.add_argument("--interface", default="wlanpi0")
+    pc.add_argument("--channels", help="channel numbers, e.g. 1,6,11,36,149")
+    pc.add_argument("--freqs", help="explicit MHz, e.g. 5955,5975 (6 GHz)")
+    pc.add_argument("--width", type=int, default=20, choices=[20, 40, 80, 160])
+    pc.add_argument("--dwell", type=int, default=250, help="dwell ms per channel")
+    pc.add_argument("--filter", help="pcap/BPF filter string")
+    pc.add_argument("--out", help="write to this file instead of stdout")
+
+    def add_client_args(p):
+        p.add_argument("--url", default=DEFAULT_URL)
+        p.add_argument("--token", help="wlanpi-core JWT")
+        p.add_argument("--token-env", default="WLANPI_CAP_TOKEN")
+        p.add_argument("--refresh", type=float, default=3.0, help="table interval s")
+        p.add_argument("--duration", type=float, help="stop after N seconds")
+        p.add_argument("--raw-out", help="write raw pcapng stream to this file")
+
+    pr = sub.add_parser("run", help="start or subscribe to a capture")
+    add_client_args(pr)
+    g = pr.add_mutually_exclusive_group(required=True)
+    g.add_argument("--config", help="config JSON to start a capture (owner)")
+    g.add_argument("--subscribe", help="session id to listen to (read-only)")
+
+    pl = sub.add_parser("list", help="list running capture sessions")
+    add_client_args(pl)
+
+    args = parser.parse_args()
+
+    if args.mode == "config":
+        build_config(args)
+    else:
+        try:
+            if args.mode == "list":
+                asyncio.run(run_list(args))
+            elif args.config:
+                asyncio.run(run_owner(args))
+            else:
+                asyncio.run(run_subscriber(args))
+        except KeyboardInterrupt:
+            pass
+        except OSError as exc:
+            sys.exit(f"could not connect to {args.url}: {exc}")
+        except (RuntimeError, asyncio.TimeoutError) as exc:
+            sys.exit(f"error: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/capture_harness/capture_harness.py
+++ b/tools/capture_harness/capture_harness.py
@@ -442,6 +442,31 @@ async def _consume(ws, table: ScanTable, refresh: float, deadline: Optional[floa
             last_print = now
 
 
+def _print_config(config: Optional[dict]) -> None:
+    if not config:
+        print("  (running config unavailable)")
+        return
+    for iface, cfg in (config.get("interfaces") or {}).items():
+        chans = ",".join(
+            str(freq_to_channel(c["freq"]) or c["freq"])
+            for c in cfg.get("channels", [])
+        )
+        print(f"  {iface}: channels [{chans}] dwell {cfg.get('dwell_time')}ms")
+    if config.get("pcap_filter"):
+        print(f"  filter: {config['pcap_filter']}")
+
+
+async def _find_sessions(ws) -> list:
+    await ws.send(json.dumps({"command": "list_sessions"}))
+    while True:
+        msg = await asyncio.wait_for(ws.recv(), timeout=AUTH_TIMEOUT)
+        if isinstance(msg, bytes):
+            continue
+        event = json.loads(msg)
+        if event.get("code") == "SESSIONS":
+            return event.get("data", {}).get("sessions", [])
+
+
 async def run_owner(args) -> None:
     token = resolve_token(args)
     with open(args.config) as fh:
@@ -452,6 +477,20 @@ async def run_owner(args) -> None:
     async with websockets.connect(args.url, max_size=None) as ws:
         did = await _authenticate(ws, token)
         print(f"[auth] authenticated as did={did}", file=sys.stderr)
+
+        # Own-vs-subscribe pre-flight: if a capture is already running on an
+        # interface we want, tell the user they could subscribe instead.
+        wanted = set(interfaces.keys())
+        for sess in await _find_sessions(ws):
+            clash = wanted & set(sess.get("interfaces", []))
+            if clash:
+                print(
+                    f"[note] {sorted(clash)} already captured by session "
+                    f"{sess['session_id']} (owner did={sess.get('owner')}). "
+                    f"start will fail with INTERFACE_IN_USE; to observe it run:\n"
+                    f"    run --subscribe {sess['session_id']} --url {args.url}",
+                    file=sys.stderr,
+                )
 
         await ws.send(json.dumps({"command": "configure", "interfaces": interfaces}))
         await ws.send(
@@ -475,6 +514,7 @@ async def run_owner(args) -> None:
             elif event.get("event") == "error":
                 raise RuntimeError(f"start failed: {event.get('data')}")
         print("=" * 60)
+        print(f"  ROLE: OWNER (in control of this capture)")
         print(f"  CAPTURE SESSION: {session_id}")
         print(f"  subscribe from another instance:")
         print(f"    capture_harness.py run --subscribe {session_id} "
@@ -507,6 +547,23 @@ async def run_subscriber(args) -> None:
         await ws.send(
             json.dumps({"command": "subscribe", "session_id": args.subscribe})
         )
+        # Learn the running config before consuming, so we are not blind.
+        while True:
+            msg = await asyncio.wait_for(ws.recv(), timeout=AUTH_TIMEOUT)
+            if isinstance(msg, bytes):
+                continue
+            event = json.loads(msg)
+            if event.get("code") == "SUBSCRIBED":
+                data = event.get("data", {})
+                print("=" * 60)
+                print(f"  ROLE: SUBSCRIBER (read-only, not in control)")
+                print(f"  session {args.subscribe} owned by "
+                      f"did={data.get('owner')}")
+                _print_config(data.get("config"))
+                print("=" * 60)
+                break
+            if event.get("event") == "error":
+                raise RuntimeError(f"subscribe failed: {event.get('data')}")
         raw_fp = open(args.raw_out, "wb") if args.raw_out else None
         table = ScanTable()
         deadline = time.monotonic() + args.duration if args.duration else None
@@ -534,11 +591,12 @@ async def run_list(args) -> None:
                 sessions = event.get("data", {}).get("sessions", [])
                 if not sessions:
                     print("no running capture sessions")
-                for s in sessions:
+                for sess in sessions:
                     print(
-                        f"{s['session_id']}  owner={s.get('owner')}  "
-                        f"interfaces={','.join(s.get('interfaces', []))}"
+                        f"{sess['session_id']}  owner={sess.get('owner')}  "
+                        f"interfaces={','.join(sess.get('interfaces', []))}"
                     )
+                    _print_config(sess.get("config"))
                 return
 
 

--- a/wlanpi_core/api/api_v1/endpoints/streaming_api.py
+++ b/wlanpi_core/api/api_v1/endpoints/streaming_api.py
@@ -3,6 +3,7 @@ WebSocket streaming endpoints.
 
 See docs/API-INTEGRATION-GUIDE.md §7 for the capture command protocol.
 """
+import asyncio
 import json
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -15,6 +16,81 @@ from wlanpi_core.streaming.models import CaptureConfigurations
 router = APIRouter()
 log = get_logger(__name__)
 manager = ConnectionManager()
+
+#: Close code for authentication failures (WebSocket has no HTTP 401).
+WS_AUTH_CLOSE_CODE = 4401
+#: Seconds a fresh connection has to present its auth message.
+AUTH_TIMEOUT_SECONDS = 10.0
+
+
+async def _reject(websocket: WebSocket, code: str, message: str) -> None:
+    await manager.send_message_event(websocket, "error", code, message)
+    try:
+        await websocket.close(code=WS_AUTH_CLOSE_CODE)
+    except RuntimeError:
+        pass
+    await manager.disconnect(websocket)
+
+
+async def _authenticate(websocket: WebSocket) -> bool:
+    """First-message auth (#141): the first frame must be
+    {"command": "auth", "token": "<core JWT>"} within AUTH_TIMEOUT_SECONDS.
+
+    Tokens are never accepted in the URL: query strings end up in proxy and
+    access logs, so a ?token=... connection is refused outright to keep the
+    unsafe pattern from taking root.
+    """
+    if "token" in websocket.query_params:
+        await _reject(
+            websocket,
+            "AUTH_TOKEN_IN_URL",
+            "Tokens are not accepted in the URL (it is logged); "
+            "send {\"command\": \"auth\", \"token\": ...} as the first message.",
+        )
+        return False
+
+    try:
+        raw = await asyncio.wait_for(
+            websocket.receive_text(), timeout=AUTH_TIMEOUT_SECONDS
+        )
+        data = json.loads(raw)
+    except asyncio.TimeoutError:
+        await _reject(
+            websocket, "AUTH_TIMEOUT", "No auth message received in time."
+        )
+        return False
+    except json.JSONDecodeError:
+        await _reject(websocket, "AUTH_REQUIRED", "First message must be valid JSON auth.")
+        return False
+
+    if not isinstance(data, dict) or data.get("command") != "auth":
+        await _reject(
+            websocket,
+            "AUTH_REQUIRED",
+            "Authenticate first: {\"command\": \"auth\", \"token\": ...}.",
+        )
+        return False
+
+    token = data.get("token")
+    if not isinstance(token, str) or not token:
+        await _reject(websocket, "AUTH_FAILED", "Auth message carries no token.")
+        return False
+
+    try:
+        result = await websocket.app.state.token_manager.verify_token(token)
+    except Exception:
+        log.exception("Capture WS token verification errored")
+        await _reject(websocket, "AUTH_FAILED", "Token verification failed.")
+        return False
+
+    if not result.is_valid:
+        await _reject(websocket, "AUTH_FAILED", "Token verification failed.")
+        return False
+
+    did = result.device_id or (result.payload or {}).get("did")
+    manager.authenticate(websocket, did)
+    await manager.send_event(websocket, "status", "AUTH_OK", {"did": did})
+    return True
 
 
 @router.websocket(
@@ -34,7 +110,16 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     | `start` | `{ "interfaces": ["wlanpi0"], "pcap_filter": "…" }` | Begin streaming |
     | `stop` | `{}` | Stop capture for this client |
 
-    **Auth:** not enforced today — treat as privileged; REST session API will add tokens.
+    **Auth:** required. The first message must be
+    `{ "command": "auth", "token": "<core JWT>" }` (within 10s); anything else,
+    an invalid token, or a `?token=` query parameter closes the socket with
+    code 4401. All later commands run as the authenticated principal (`did`).
+
+    **Sessions & subscribers:** `start` returns a `session_id` in the
+    `CAPTURE_STARTED` event. Any other authenticated connection may
+    `{ "command": "subscribe", "session_id": … }` to receive the same binary
+    stream read-only (`list_sessions` enumerates running captures); only the
+    owning connection can `configure`/`stop`. `unsubscribe` detaches.
 
     **Long-running:** keep connection open for entire capture session; use `stop` before disconnect.
 
@@ -43,6 +128,9 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     await manager.connect(websocket)
 
     try:
+        if not await _authenticate(websocket):
+            return
+
         while True:
             try:
                 msg = await websocket.receive_text()
@@ -98,6 +186,23 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
             elif command == "stop":
                 await manager.stop_streaming(websocket)
+
+            elif command == "subscribe":
+                await manager.subscribe(websocket, data.get("session_id"))
+
+            elif command == "unsubscribe":
+                await manager.unsubscribe(websocket)
+
+            elif command == "list_sessions":
+                await manager.send_session_list(websocket)
+
+            elif command == "auth":
+                await manager.send_message_event(
+                    websocket,
+                    "status",
+                    "ALREADY_AUTHENTICATED",
+                    "This connection is already authenticated.",
+                )
 
             else:
                 await manager.send_message_event(

--- a/wlanpi_core/api/api_v1/endpoints/streaming_api.py
+++ b/wlanpi_core/api/api_v1/endpoints/streaming_api.py
@@ -214,6 +214,12 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
     except WebSocketDisconnect:
         await manager.disconnect(websocket)
+    except RuntimeError as e:
+        # Starlette raises "WebSocket is not connected" when the peer closes
+        # mid-operation - a disconnect race, not a server fault. Log at debug
+        # so a genuine RuntimeError is still traceable without noise.
+        log.debug(f"WebSocket closed mid-operation: {e!r}")
+        await manager.disconnect(websocket)
     except Exception as e:
         log.error(f"Unhandled error in websocket endpoint: {e!r}")
         await manager.disconnect(websocket)

--- a/wlanpi_core/app.py
+++ b/wlanpi_core/app.py
@@ -590,10 +590,14 @@ def create_app(debug: bool = False):
                 "tags": ["streaming"],
                 "summary": "Packet capture WebSocket",
                 "description": (
-                    "Upgrade to WebSocket for live Wi-Fi capture. Send JSON text "
-                    "commands (`get_supported_frequencies`, `configure`, `start`, "
-                    "`stop`); receive JSON events and binary pcapng frames. "
-                    "Auth not enforced today — treat as privileged."
+                    "Upgrade to WebSocket for live Wi-Fi capture. First message must "
+                    "authenticate: {\"command\": \"auth\", \"token\": <core JWT>} "
+                    "(no tokens in the URL; failure closes with code 4401). Send "
+                    "JSON text commands (`get_supported_frequencies`, `configure`, "
+                    "`start`, `stop`, `subscribe`, `unsubscribe`, `list_sessions`); "
+                    "receive JSON events and binary pcapng frames. `start` returns "
+                    "a session_id other authenticated clients can subscribe to "
+                    "read-only; only the owner controls the capture."
                 ),
                 "operationId": "streaming_capture_websocket",
                 "responses": {

--- a/wlanpi_core/streaming/connection_manager.py
+++ b/wlanpi_core/streaming/connection_manager.py
@@ -2,13 +2,16 @@ import asyncio
 import json
 import re
 import secrets
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from fastapi import WebSocket
 
 from wlanpi_core.constants import DUMPCAP_FILE, IW_FILE
 from wlanpi_core.core.logging import get_logger
+from wlanpi_core.utils import network_config
 from wlanpi_core.utils.general import run_command_async, terminate_process_async
+from wlanpi_core.utils.validation import validate_namespace_name
+from wlanpi_core.wlan.scan import iter_adapters
 from wlanpi_core.streaming.models import (
     CaptureInterfaceConfig,
     CaptureStart,
@@ -39,6 +42,7 @@ class ConnectionManager:
             "did": None,
             "session_id": None,
             "session_config": None,
+            "namespace": None,
             "subscribers": set(),
             "subscribed_to": None,
         }
@@ -104,6 +108,7 @@ class ConnectionManager:
         session_id = client.get("session_id")
         client["session_id"] = None
         client["session_config"] = None
+        client["namespace"] = None
         if session_id:
             self.sessions.pop(session_id, None)
         for subscriber in list(client.get("subscribers", set())):
@@ -230,24 +235,32 @@ class ConnectionManager:
 
     async def send_supported_frequencies(self, websocket: WebSocket) -> None:
         try:
-            output = (
-                await run_command_async(
-                    [IW_FILE, "dev"],
-                    timeout=_IW_TIMEOUT_SEC,
-                )
-            ).stdout
-            interfaces = re.findall(r"Interface (wlanpi\d+)", output)
+            # Discover capture adapters across all namespaces via core's own
+            # enumeration, then query each phy inside its namespace, so a
+            # namespaced adapter is not invisible here.
+            from wlanpi_core.adapters.interface import get_interface_info
+
+            status = await asyncio.to_thread(network_config.status)
+            adapters = [
+                a for a in iter_adapters(status) if a["iface"].startswith("wlanpi")
+            ]
 
             freqs_by_iface = {}
-
-            for iface in interfaces:
+            for adapter in adapters:
+                iface = adapter["iface"]
+                namespace = adapter["namespace"]
                 try:
-                    index = int(re.search(r"wlanpi(\d+)", iface).group(1))
-                    phy = f"phy{index}"
-
+                    info = await asyncio.to_thread(
+                        get_interface_info, iface, namespace
+                    )
+                    phy = (info or {}).get("phy")
+                    if not phy:
+                        freqs_by_iface[iface] = []
+                        continue
                     chan_output = (
                         await run_command_async(
-                            [IW_FILE, "phy", phy, "channels"],
+                            self._ns_prefix(namespace)
+                            + [IW_FILE, "phy", phy, "channels"],
                             timeout=_IW_TIMEOUT_SEC,
                         )
                     ).stdout
@@ -275,6 +288,46 @@ class ConnectionManager:
                 "FREQ_FETCH_FAILED",
                 f"Failed to fetch supported frequencies: {e}",
             )
+
+    @staticmethod
+    def _ns_prefix(namespace: Optional[str]) -> list:
+        """Command prefix to run in a network namespace. Empty for root.
+
+        wlanpi-core runs as root, so `ip netns exec` needs no sudo. The whole
+        phy moves into a namespace together, so all vifs on it share one ns.
+        """
+        if not namespace:
+            return []
+        return ["ip", "netns", "exec", validate_namespace_name(namespace)]
+
+    async def _resolve_namespace(
+        self, interfaces: list[str]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Find the namespace the capture interfaces live in, via core's own
+        adapter enumeration (network_config.status) - never a bespoke iw call.
+
+        Returns (namespace, error). namespace is None for root. error is a
+        short reason string when the interfaces are missing or split across
+        namespaces (dumpcap cannot span netns).
+        """
+        status = await asyncio.to_thread(network_config.status)
+        adapters = iter_adapters(status)
+        by_name: Dict[str, list] = {}
+        for a in adapters:
+            by_name.setdefault(a["iface"], []).append(a)
+
+        namespaces = set()
+        for iface in interfaces:
+            records = by_name.get(iface)
+            if not records:
+                return None, f"interface not found on this device: {iface}"
+            namespaces.update(r["namespace"] for r in records)
+        if len(namespaces) > 1:
+            return None, (
+                "capture interfaces span multiple namespaces "
+                f"({sorted(str(n) for n in namespaces)}); one capture cannot"
+            )
+        return (namespaces.pop() if namespaces else None), None
 
     async def start_streaming(
         self,
@@ -342,6 +395,15 @@ class ConnectionManager:
             )
             return
 
+        namespace, ns_error = await self._resolve_namespace(interfaces)
+        if ns_error:
+            self._release_interfaces(websocket)
+            await self.send_message_event(
+                websocket, "error", "INTERFACE_NOT_AVAILABLE", ns_error
+            )
+            return
+        client["namespace"] = namespace
+
         for iface in interfaces:
             config = client["configs"].get(iface)
             if not config:
@@ -352,7 +414,7 @@ class ConnectionManager:
                 freq = first.get("freq")
                 width = first.get("width")
                 if freq and width:
-                    error = await self._set_channel(iface, freq, width)
+                    error = await self._set_channel(iface, freq, width, namespace)
                     if error:
                         await self.send_message_event(
                             websocket,
@@ -361,7 +423,7 @@ class ConnectionManager:
                             f"Could not set initial channel for {iface}: {error}",
                         )
 
-        args = [DUMPCAP_FILE]
+        args = self._ns_prefix(namespace) + [DUMPCAP_FILE]
         for iface in interfaces:
             args += ["-i", iface]
         if pcap_filter:
@@ -506,7 +568,9 @@ class ConnectionManager:
             width = ch.get("width")
 
             if freq and width:
-                error = await self._set_channel(iface, freq, width)
+                error = await self._set_channel(
+                    iface, freq, width, self.clients.get(websocket, {}).get("namespace")
+                )
                 if not error:
                     await self.send_message_event(
                         websocket,
@@ -546,7 +610,9 @@ class ConnectionManager:
                 websocket, "error", "CHANNEL_HOP_ERROR", f"{iface} hopping failed."
             )
 
-    async def _set_channel(self, iface: str, freq: int, width: int) -> Optional[str]:
+    async def _set_channel(
+        self, iface: str, freq: int, width: int, namespace: Optional[str] = None
+    ) -> Optional[str]:
         """Tune a capture interface. Returns None on success, else a short
         reason suitable for the CHANNEL_SET_FAILED event (e.g. iw's
         'Device or resource busy (-16)' when a managed vif on the same phy
@@ -558,7 +624,9 @@ class ConnectionManager:
         except ValueError as exc:
             return str(exc)
 
-        cmd = [IW_FILE, "dev", iface, "set", "freq", str(freq), str(width)]
+        cmd = self._ns_prefix(namespace) + [
+            IW_FILE, "dev", iface, "set", "freq", str(freq), str(width)
+        ]
 
         if width >= 40:
             center_frequency = self._center_frequency(freq, width)

--- a/wlanpi_core/streaming/connection_manager.py
+++ b/wlanpi_core/streaming/connection_manager.py
@@ -127,6 +127,7 @@ class ConnectionManager:
             "session_id": session_id,
             "owner": owner_client.get("did"),
             "interfaces": sorted(owner_client.get("interfaces", set())),
+            "namespace": owner_client.get("namespace"),
             "config": owner_client.get("session_config"),
         }
 

--- a/wlanpi_core/streaming/connection_manager.py
+++ b/wlanpi_core/streaming/connection_manager.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 import re
-from typing import Any, Dict
+import secrets
+from typing import Any, Dict, Optional
 
 from fastapi import WebSocket
 
@@ -24,6 +25,9 @@ class ConnectionManager:
     def __init__(self):
         self.clients: Dict[WebSocket, Dict[str, Any]] = {}
         self.interface_owners: Dict[str, WebSocket] = {}
+        # Running captures by session id -> owning WebSocket. Sessions exist
+        # so other authenticated principals can subscribe read-only (#141).
+        self.sessions: Dict[str, WebSocket] = {}
 
     async def connect(self, websocket: WebSocket) -> None:
         self.clients[websocket] = {
@@ -32,8 +36,23 @@ class ConnectionManager:
             "task": None,
             "channel_tasks": {},
             "interfaces": set(),
+            "did": None,
+            "session_id": None,
+            "subscribers": set(),
+            "subscribed_to": None,
         }
         await websocket.accept()
+
+    def authenticate(self, websocket: WebSocket, did: str) -> None:
+        """Record the verified principal for this socket. Commands are only
+        dispatched after this is set (first-message auth in the endpoint)."""
+        client = self.clients.get(websocket)
+        if client is not None:
+            client["did"] = did
+
+    def is_authenticated(self, websocket: WebSocket) -> bool:
+        client = self.clients.get(websocket)
+        return bool(client and client.get("did"))
 
     def _claim_interfaces(
         self, websocket: WebSocket, interfaces: list[str]
@@ -64,6 +83,100 @@ class ConnectionManager:
                 self.interface_owners.pop(iface, None)
         client["interfaces"] = set()
 
+    def _detach_subscriber(self, websocket: WebSocket) -> None:
+        client = self.clients.get(websocket)
+        if not client:
+            return
+        session_id = client.get("subscribed_to")
+        client["subscribed_to"] = None
+        if not session_id:
+            return
+        owner_ws = self.sessions.get(session_id)
+        if owner_ws is not None:
+            owner_client = self.clients.get(owner_ws)
+            if owner_client:
+                owner_client["subscribers"].discard(websocket)
+
+    async def _end_session(self, client: Dict[str, Any], code: str, message: str) -> None:
+        """Unregister a finished capture and notify/detach its subscribers.
+        Idempotent: safe to call from both stream teardown and stop paths."""
+        session_id = client.get("session_id")
+        client["session_id"] = None
+        if session_id:
+            self.sessions.pop(session_id, None)
+        for subscriber in list(client.get("subscribers", set())):
+            sub_client = self.clients.get(subscriber)
+            if sub_client:
+                sub_client["subscribed_to"] = None
+            client["subscribers"].discard(subscriber)
+            await self.send_message_event(subscriber, "status", code, message)
+
+    async def subscribe(self, websocket: WebSocket, session_id: Optional[str]) -> None:
+        """Attach this socket as a read-only listener on a running capture.
+
+        Any authenticated principal on the device may listen; only the owning
+        socket can configure or stop the capture (control is not shareable).
+        """
+        client = self.clients.get(websocket)
+        if client is None:
+            return
+        owner_ws = self.sessions.get(session_id) if session_id else None
+        if owner_ws is None:
+            await self.send_message_event(
+                websocket, "error", "SESSION_NOT_FOUND",
+                f"No running capture session: {session_id}",
+            )
+            return
+        if owner_ws is websocket:
+            await self.send_message_event(
+                websocket, "error", "SESSION_IS_OWN",
+                "This socket owns that capture; it already receives its stream.",
+            )
+            return
+        self._detach_subscriber(websocket)
+        owner_client = self.clients[owner_ws]
+        owner_client["subscribers"].add(websocket)
+        client["subscribed_to"] = session_id
+        await self.send_event(
+            websocket, "status", "SUBSCRIBED",
+            {
+                "session_id": session_id,
+                "interfaces": sorted(owner_client.get("interfaces", set())),
+            },
+        )
+
+    async def unsubscribe(self, websocket: WebSocket) -> None:
+        session_id = (self.clients.get(websocket) or {}).get("subscribed_to")
+        self._detach_subscriber(websocket)
+        await self.send_event(
+            websocket, "status", "UNSUBSCRIBED", {"session_id": session_id}
+        )
+
+    async def send_session_list(self, websocket: WebSocket) -> None:
+        sessions = []
+        for session_id, owner_ws in self.sessions.items():
+            owner_client = self.clients.get(owner_ws, {})
+            sessions.append(
+                {
+                    "session_id": session_id,
+                    "owner": owner_client.get("did"),
+                    "interfaces": sorted(owner_client.get("interfaces", set())),
+                }
+            )
+        await self.send_event(websocket, "status", "SESSIONS", {"sessions": sessions})
+
+    async def _broadcast_chunk(
+        self, owner_ws: WebSocket, client: Dict[str, Any], chunk: bytes
+    ) -> None:
+        # Owner send failures propagate and end the capture (as before).
+        # A failing subscriber is dropped without disturbing the capture.
+        await owner_ws.send_bytes(chunk)
+        for subscriber in list(client.get("subscribers", set())):
+            try:
+                await subscriber.send_bytes(chunk)
+            except Exception:
+                self._detach_subscriber(subscriber)
+
     async def _stop_channel_tasks(self, client: Dict[str, Any]) -> None:
         channel_tasks = list(client.get("channel_tasks", {}).values())
         client["channel_tasks"] = {}
@@ -84,6 +197,7 @@ class ConnectionManager:
             self.clients[websocket]["configs"][iface] = validated.model_dump()
 
     async def disconnect(self, websocket: WebSocket) -> None:
+        self._detach_subscriber(websocket)
         try:
             await self.stop_streaming(websocket)
         except Exception as e:
@@ -270,7 +384,7 @@ class ConnectionManager:
                     chunk = await proc.stdout.read(4096)
                     if not chunk:
                         break
-                    await websocket.send_bytes(chunk)
+                    await self._broadcast_chunk(websocket, client, chunk)
                 await self.send_message_event(
                     websocket, "status", "CAPTURE_ENDED", "Capture ended."
                 )
@@ -287,6 +401,7 @@ class ConnectionManager:
                 await terminate_process_async(proc)
                 await self._stop_channel_tasks(client)
                 self._release_interfaces(websocket)
+                await self._end_session(client, "CAPTURE_ENDED", "Capture ended.")
                 if client.get("proc") is proc:
                     client["proc"] = None
                 if client.get("task") is asyncio.current_task():
@@ -308,11 +423,19 @@ class ConnectionManager:
                 )
                 client["channel_tasks"][iface] = task
 
-        await self.send_message_event(
+        session_id = f"cap_{secrets.token_hex(4)}"
+        client["session_id"] = session_id
+        self.sessions[session_id] = websocket
+
+        await self.send_event(
             websocket,
             "status",
             "CAPTURE_STARTED",
-            f"Started capture on {', '.join(interfaces)}",
+            {
+                "message": f"Started capture on {', '.join(interfaces)}",
+                "session_id": session_id,
+                "interfaces": sorted(interfaces),
+            },
         )
 
     async def stop_streaming(self, websocket: WebSocket, notify: bool = True) -> None:
@@ -338,6 +461,7 @@ class ConnectionManager:
 
         await self._stop_channel_tasks(client)
         self._release_interfaces(websocket)
+        await self._end_session(client, "CAPTURE_STOPPED", "Capture stopped.")
 
         client["task"] = None
         client["proc"] = None

--- a/wlanpi_core/streaming/connection_manager.py
+++ b/wlanpi_core/streaming/connection_manager.py
@@ -552,18 +552,28 @@ class ConnectionManager:
                 return "no valid center frequency for this channel/width"
             cmd.append(str(center_frequency))
 
-        try:
-            result = await run_command_async(
-                cmd,
-                raise_on_fail=False,
-                timeout=_IW_TIMEOUT_SEC,
-            )
-        except Exception as exc:
-            return str(exc)
-        if result.success:
-            return None
-        detail = (result.stderr or result.stdout or "").strip().splitlines()
-        return detail[-1] if detail else f"iw exited {result.return_code}"
+        # A shared phy is briefly locked while another vif scans (e.g.
+        # wpa_supplicant's periodic scan on a disconnected managed vif), so
+        # EBUSY here is often transient: retry once before reporting.
+        detail = ""
+        for attempt in range(2):
+            try:
+                result = await run_command_async(
+                    cmd,
+                    raise_on_fail=False,
+                    timeout=_IW_TIMEOUT_SEC,
+                )
+            except Exception as exc:
+                return str(exc)
+            if result.success:
+                return None
+            lines = (result.stderr or result.stdout or "").strip().splitlines()
+            detail = lines[-1] if lines else f"iw exited {result.return_code}"
+            if attempt == 0 and "busy" in detail.lower():
+                await asyncio.sleep(0.3)
+                continue
+            break
+        return detail
 
     def _center_frequency(self, freq: int, channel_width: int) -> int:
         def compute_center(start: int, span: int) -> int:

--- a/wlanpi_core/streaming/connection_manager.py
+++ b/wlanpi_core/streaming/connection_manager.py
@@ -417,6 +417,11 @@ class ConnectionManager:
                 if freq and width:
                     error = await self._set_channel(iface, freq, width, namespace)
                     if error:
+                        # Warn but continue: capture on whatever channel the
+                        # radio is currently on rather than aborting. This is
+                        # what keeps single-radio devices usable when the
+                        # managed vif briefly holds the phy (see the busy retry
+                        # in _set_channel). Do not turn this into a hard abort.
                         await self.send_message_event(
                             websocket,
                             "error",
@@ -560,6 +565,7 @@ class ConnectionManager:
                 log.warning("Capture shutdown failed for a client: %r", exc)
         self.clients.clear()
         self.interface_owners.clear()
+        self.sessions.clear()
 
     async def _hop_channels(
         self, websocket: WebSocket, iface: str, channels: list, dwell_time_ms: int

--- a/wlanpi_core/streaming/connection_manager.py
+++ b/wlanpi_core/streaming/connection_manager.py
@@ -347,13 +347,13 @@ class ConnectionManager:
                 freq = first.get("freq")
                 width = first.get("width")
                 if freq and width:
-                    success = await self._set_channel(iface, freq, width)
-                    if not success:
+                    error = await self._set_channel(iface, freq, width)
+                    if error:
                         await self.send_message_event(
                             websocket,
                             "error",
                             "CHANNEL_SET_FAILED",
-                            f"Could not set initial channel for {iface}",
+                            f"Could not set initial channel for {iface}: {error}",
                         )
 
         args = [DUMPCAP_FILE]
@@ -492,8 +492,8 @@ class ConnectionManager:
             width = ch.get("width")
 
             if freq and width:
-                success = await self._set_channel(iface, freq, width)
-                if success:
+                error = await self._set_channel(iface, freq, width)
+                if not error:
                     await self.send_message_event(
                         websocket,
                         "info",
@@ -505,7 +505,7 @@ class ConnectionManager:
                         websocket,
                         "error",
                         "CHANNEL_SET_FAILED",
-                        f"{iface}: failed to set {freq} MHz / {width} MHz",
+                        f"{iface}: failed to set {freq} MHz / {width} MHz ({error})",
                     )
 
         try:
@@ -532,20 +532,24 @@ class ConnectionManager:
                 websocket, "error", "CHANNEL_HOP_ERROR", f"{iface} hopping failed."
             )
 
-    async def _set_channel(self, iface: str, freq: int, width: int) -> bool:
+    async def _set_channel(self, iface: str, freq: int, width: int) -> Optional[str]:
+        """Tune a capture interface. Returns None on success, else a short
+        reason suitable for the CHANNEL_SET_FAILED event (e.g. iw's
+        'Device or resource busy (-16)' when a managed vif on the same phy
+        blocks retuning - common on single-radio devices)."""
         try:
             iface = validate_capture_interface(iface)
             freq = validate_capture_frequency(freq)
             width = validate_capture_width(width)
-        except ValueError:
-            return False
+        except ValueError as exc:
+            return str(exc)
 
         cmd = [IW_FILE, "dev", iface, "set", "freq", str(freq), str(width)]
 
         if width >= 40:
             center_frequency = self._center_frequency(freq, width)
             if center_frequency < 0:
-                return False
+                return "no valid center frequency for this channel/width"
             cmd.append(str(center_frequency))
 
         try:
@@ -554,9 +558,12 @@ class ConnectionManager:
                 raise_on_fail=False,
                 timeout=_IW_TIMEOUT_SEC,
             )
-            return result.success
-        except Exception:
-            return False
+        except Exception as exc:
+            return str(exc)
+        if result.success:
+            return None
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        return detail[-1] if detail else f"iw exited {result.return_code}"
 
     def _center_frequency(self, freq: int, channel_width: int) -> int:
         def compute_center(start: int, span: int) -> int:

--- a/wlanpi_core/streaming/connection_manager.py
+++ b/wlanpi_core/streaming/connection_manager.py
@@ -38,6 +38,7 @@ class ConnectionManager:
             "interfaces": set(),
             "did": None,
             "session_id": None,
+            "session_config": None,
             "subscribers": set(),
             "subscribed_to": None,
         }
@@ -102,6 +103,7 @@ class ConnectionManager:
         Idempotent: safe to call from both stream teardown and stop paths."""
         session_id = client.get("session_id")
         client["session_id"] = None
+        client["session_config"] = None
         if session_id:
             self.sessions.pop(session_id, None)
         for subscriber in list(client.get("subscribers", set())):
@@ -110,6 +112,18 @@ class ConnectionManager:
                 sub_client["subscribed_to"] = None
             client["subscribers"].discard(subscriber)
             await self.send_message_event(subscriber, "status", code, message)
+
+    def _session_descriptor(self, session_id: str, owner_ws: WebSocket) -> dict:
+        """Public description of a running capture: who owns it and the exact
+        config it is running (channels/width/dwell per interface + filter), so
+        a subscriber is never blind to what it is receiving."""
+        owner_client = self.clients.get(owner_ws, {})
+        return {
+            "session_id": session_id,
+            "owner": owner_client.get("did"),
+            "interfaces": sorted(owner_client.get("interfaces", set())),
+            "config": owner_client.get("session_config"),
+        }
 
     async def subscribe(self, websocket: WebSocket, session_id: Optional[str]) -> None:
         """Attach this socket as a read-only listener on a running capture.
@@ -139,10 +153,7 @@ class ConnectionManager:
         client["subscribed_to"] = session_id
         await self.send_event(
             websocket, "status", "SUBSCRIBED",
-            {
-                "session_id": session_id,
-                "interfaces": sorted(owner_client.get("interfaces", set())),
-            },
+            self._session_descriptor(session_id, owner_ws),
         )
 
     async def unsubscribe(self, websocket: WebSocket) -> None:
@@ -153,16 +164,10 @@ class ConnectionManager:
         )
 
     async def send_session_list(self, websocket: WebSocket) -> None:
-        sessions = []
-        for session_id, owner_ws in self.sessions.items():
-            owner_client = self.clients.get(owner_ws, {})
-            sessions.append(
-                {
-                    "session_id": session_id,
-                    "owner": owner_client.get("did"),
-                    "interfaces": sorted(owner_client.get("interfaces", set())),
-                }
-            )
+        sessions = [
+            self._session_descriptor(session_id, owner_ws)
+            for session_id, owner_ws in self.sessions.items()
+        ]
         await self.send_event(websocket, "status", "SESSIONS", {"sessions": sessions})
 
     async def _broadcast_chunk(
@@ -425,6 +430,14 @@ class ConnectionManager:
 
         session_id = f"cap_{secrets.token_hex(4)}"
         client["session_id"] = session_id
+        # Snapshot the exact running config so list_sessions / SUBSCRIBED can
+        # report it to subscribers (who otherwise only see raw frames).
+        client["session_config"] = {
+            "interfaces": {
+                iface: client["configs"].get(iface, {}) for iface in interfaces
+            },
+            "pcap_filter": pcap_filter,
+        }
         self.sessions[session_id] = websocket
 
         await self.send_event(
@@ -435,6 +448,7 @@ class ConnectionManager:
                 "message": f"Started capture on {', '.join(interfaces)}",
                 "session_id": session_id,
                 "interfaces": sorted(interfaces),
+                "config": client["session_config"],
             },
         )
 


### PR DESCRIPTION
## Summary
- **P6 / #141:** Capture WebSocket requires first-message auth `{ "command": "auth", "token": "<JWT>" }` within 10s; invalid/missing auth or `?token=` in the URL closes with code **4401**.
- Running captures are **owned sessions**: other authenticated principals may `subscribe` / `list_sessions` / `unsubscribe` read-only; only the owner can `configure` / `stop`.
- Tests in `tests/test_capture_ws_auth.py` (handshake, timeout, ownership, subscribers).
- Also on this branch (same streaming surface): surface `iw` failure reason in `CHANNEL_SET_FAILED`, and one retry when the phy is transiently busy — split out if prefer a narrower PR.

## Test plan
- [ ] CI green (`tox` / Run Python Tests)
- [ ] Unauthenticated or non-auth first message → error event + close 4401
- [ ] `?token=` refused (`AUTH_TOKEN_IN_URL`)
- [ ] Valid auth → `AUTH_OK` with `did`; start → `session_id`; second client can subscribe; non-owner cannot stop
- [ ] Revoked/invalid token refused

## Related
- Plan: `docs/mcp-auth-plan.md` §4.1 P6
- Depends on working JWT verification (pairs cleanly with P1/P2 on device)
